### PR TITLE
harden encryption library for v2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,24 +2,42 @@ name: Go
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [master]
   pull_request:
-    branches: [ "master" ]
+    branches: [master]
+
+permissions:
+  contents: read
 
 jobs:
-
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+      - name: Format
+        run: test -z "$(gofmt -d .)"
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test ./... -race -count=2 -coverprofile=coverage.out
+      - name: Enforce coverage
+        run: |
+          total=$(go tool cover -func=coverage.out | awk '/^total:/ {gsub("%", "", $3); print $3}')
+          awk -v total="$total" 'BEGIN { if (total < 85) exit 1 }'
+      - name: Build
+        run: go build ./...
+      - name: Vulnerability scan
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1
 
-    - name: Set up Go
-      uses: actions/setup-go@v6
-      with:
-        go-version: 1.25
-
-    - name: Build
-      run: go build -v ./...
-
-    - name: Test
-      run: go test -v ./...
+  fuzz-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+      - run: go test ./... -run=^$ -fuzz=FuzzOpen -fuzztime=20s

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Structure & Module Organization
 
-This single Go module (`github.com/rusq/secure`) implements the `secure` package. Production code lives at the root: `secure.go` contains core AES-GCM operations, `stream.go` handles streams, and `string.go` and `int.go` provide JSON-friendly encrypted types. Shared errors are in `errors.go`; tests are colocated in `*_test.go` files. `README.md` documents the API, and `gimmesalt.sh` generates salt data.
+This single Go module (`github.com/rusq/secure/v2`) implements the `secure` package. Production code lives at the root: `secure.go` contains versioned AES-GCM envelopes, `stream.go` handles authenticated streams, `legacy.go` supports read-only v1 migration, and `string.go` and `int.go` provide encrypted JSON values. Tests are colocated in `*_test.go` files, and `README.md` documents the API.
 
 ## Build, Test, and Development Commands
 
@@ -12,6 +12,7 @@ This single Go module (`github.com/rusq/secure`) implements the `secure` package
 - `go vet ./...` performs standard Go static analysis.
 - `go build ./...` confirms all packages compile.
 - `gofmt -w *.go` formats Go source and tests before review.
+- `make check` runs formatting, vet, race-enabled tests, and the build.
 
 Use the Go version declared in `go.mod` (currently Go 1.25). Run `go mod tidy` only when dependencies change, and include resulting `go.mod` and `go.sum` updates together.
 
@@ -29,4 +30,4 @@ Recent commits use short, imperative, lowercase subjects such as `add stream enc
 
 ## Security & Configuration Tips
 
-Never commit real passphrases, keys, salts, or production ciphertext. The bundled salt is for testing only; applications should configure their own salt and key material. Treat changes to derivation parameters, encoding, nonce handling, or serialized layout as security-sensitive and compatibility-affecting.
+Never commit real passphrases, keys, salts, or production ciphertext. Load 32-byte keys from managed secret storage; password envelopes generate their own salts. Treat changes to derivation parameters, nonce handling, authenticated headers, or serialized layouts as security-sensitive and compatibility-affecting.

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,8 @@
 test:
 	go test ./... -race -count=2 -cover
+
+check:
+	test -z "$$(gofmt -l .)"
+	go vet ./...
+	go test ./... -race -count=2 -cover
+	go build ./...

--- a/README.md
+++ b/README.md
@@ -1,12 +1,85 @@
-# Secure (almost)
+# Secure v2
 
-Secure provides a convenient String and Int types that are encrypted with the
-AES-256 with GCM upon Marshalling/Unmarshalling to JSON.
+`github.com/rusq/secure/v2` provides versioned authenticated encryption for
+small values, JSON fields, and streams. Version 2 uses AES-256-GCM, immutable
+encryption contexts, bounded parsing, and an Argon2id password mode.
 
-It uses the standard Go runtime encryption.
+The package protects ciphertext integrity and confidentiality. It does not
+protect plaintext already present in process memory, weak passwords, or keys
+stored alongside encrypted data.
 
-Do not use the provided "salt" for anything other than testing - it may change
-from version to version to encourage to use your own salt.
+## Installation
 
-It is strongly encouraged to set your own salt with SetSalt() before using the
-encryption functions of the package.
+```sh
+go get github.com/rusq/secure/v2@v2.0.0
+```
+
+Version 2 requires Go 1.25 or newer.
+
+## Key-based encryption
+
+```go
+key := make([]byte, 32) // load this from a secret manager
+c, err := secure.NewCipher(key)
+if err != nil {
+	log.Fatal(err)
+}
+
+encrypted, err := c.EncryptString("database password")
+plaintext, err := c.DecryptString(encrypted)
+```
+
+Use `Seal` and `Open` when associated data should bind ciphertext to a field,
+tenant, or record. The same associated data must be supplied during decryption.
+
+## Password-based encryption
+
+```go
+p, err := secure.NewPasswordCipher([]byte(passphrase))
+encrypted, err := p.EncryptString("secret")
+plaintext, err := p.DecryptString(encrypted)
+```
+
+Each `SEC2.` envelope gets a random salt and records its bounded Argon2id
+parameters. The default cost is 64 MiB, three passes, and four threads.
+
+## Authenticated streams
+
+```go
+w, err := c.NewEncryptWriter(dst)
+if err != nil { /* handle */ }
+if _, err := io.Copy(w, src); err != nil { /* handle */ }
+if err := w.Close(); err != nil { /* required: writes final record */ }
+
+r, err := c.NewDecryptReader(encryptedSource)
+_, err = io.Copy(plaintextDestination, r)
+```
+
+Stream readers authenticate each 64 KiB record and reject modified, reordered,
+or truncated streams. Plaintext already returned before a later error cannot be
+retracted, so callers must discard partial output when decryption fails.
+
+## Encrypted JSON values
+
+Construct `EncryptedString` or `EncryptedInt` with a cipher before marshaling or
+unmarshaling. Plaintext JSON is rejected unless
+`WithPlaintextJSONMigration()` is explicitly supplied. A migrated value is
+encrypted on its next marshal.
+
+## Migrating from v1
+
+V2 does not expose v1 global configuration or AES-CFB stream APIs. Re-encrypt
+stored values one at a time:
+
+```go
+plaintext, err := secure.OpenLegacyWithPassphrase(oldValue, oldPassphrase,
+	secure.WithLegacySalt(oldSalt))
+newValue, err := p.Seal(plaintext, nil)
+```
+
+`OpenLegacy` accepts an already-derived 32-byte key. Legacy options support
+custom v1 salts, PBKDF2 iteration counts, armor prefixes, and base64 encodings.
+Only legacy decryption is available; v2 never creates `SEC.` ciphertext.
+
+Never commit production keys, passphrases, or salts. Treat changes to envelope
+or stream formats as compatibility-sensitive security changes.

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ unmarshaling. Plaintext JSON is rejected unless
 `WithPlaintextJSONMigration()` is explicitly supplied. A migrated value is
 encrypted on its next marshal.
 
-## Migrating from v1
+## Migrating from v0.0.4
 
-V2 does not expose v1 global configuration or AES-CFB stream APIs. Re-encrypt
+V2 does not expose v0.0.4 global configuration or AES-CFB stream APIs. Re-encrypt
 stored values one at a time:
 
 ```go
@@ -78,7 +78,7 @@ newValue, err := p.Seal(plaintext, nil)
 ```
 
 `OpenLegacy` accepts an already-derived 32-byte key. Legacy options support
-custom v1 salts, PBKDF2 iteration counts, armor prefixes, and base64 encodings.
+custom v0.0.4 salts, PBKDF2 iteration counts, armor prefixes, and base64 encodings.
 Only legacy decryption is available; v2 never creates `SEC.` ciphertext.
 
 Never commit production keys, passphrases, or salts. Treat changes to envelope

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,171 @@
+# Upgrading from v0.0.4 to v2
+
+Version 2 is a security-focused, source-breaking release. It replaces package-wide state and unauthenticated AES-CFB streams with immutable cipher instances, versioned `SEC2.` envelopes, and authenticated streaming.
+
+## Update the Dependency
+
+After `v2.0.0` is published:
+
+```sh
+go get github.com/rusq/secure/v2@v2.0.0
+go mod tidy
+```
+
+Update imports to use the semantic import suffix:
+
+```go
+import secure "github.com/rusq/secure/v2"
+```
+
+## Replace Global Configuration
+
+Create and retain an immutable encryption context instead of calling package setters:
+
+```go
+// For a 32-byte key loaded from managed secret storage.
+cipher, err := secure.NewCipher(key)
+
+// Or for password-based encryption.
+cipher, err := secure.NewPasswordCipher(passphrase)
+```
+
+Pass this instance into the components that require encryption.
+
+| v0.0.4 | v2 |
+| --- | --- |
+| `SetGlobalKey(key)` | `NewCipher(key)` |
+| `SetPassphrase(pass)` | `NewPasswordCipher(pass)` |
+| `Encrypt(text)` | `cipher.EncryptString(text)` |
+| `Decrypt(text)` | `cipher.DecryptString(text)` |
+| `SetSalt`, `SetEncoding`, `SetSignature` | Removed for new envelopes |
+| `NewWriter`, `NewReader` | Instance stream methods |
+
+Use `Seal` and `Open` when encrypting bytes or binding ciphertext to associated data:
+
+```go
+encrypted, err := cipher.Seal(plaintext, []byte("tenant:123/field:token"))
+plaintext, err = cipher.Open(encrypted, []byte("tenant:123/field:token"))
+```
+
+The associated data must match during decryption but is not stored in the envelope.
+
+## Migrate Stored Ciphertext
+
+V2 writes only `SEC2.` envelopes. It can read historical `SEC.` values through explicit migration helpers.
+
+For data encrypted with the v1 default salt:
+
+```go
+plaintext, err := secure.OpenLegacyWithPassphrase(oldValue, oldPassphrase)
+if err != nil {
+	return err
+}
+
+newValue, err := cipher.Seal(plaintext, nil)
+```
+
+Supply historical configuration when v1 used custom settings:
+
+```go
+plaintext, err := secure.OpenLegacyWithPassphrase(
+	oldValue,
+	oldPassphrase,
+	secure.WithLegacySalt(oldSalt),
+	secure.WithLegacyIterations(oldIterations),
+	secure.WithLegacyPrefix(oldPrefix),
+	secure.WithLegacyEncoding(oldEncoding),
+)
+```
+
+Use `OpenLegacy(oldValue, oldKey)` when the historical 32-byte derived key is already available.
+
+During a staged rollout:
+
+1. Read `SEC2.` values with the normal v2 cipher.
+2. Read `SEC.` values only with the legacy migration helpers.
+3. Re-encrypt successfully decoded values as `SEC2.` and persist them.
+4. Remove legacy reading after inventories confirm no `SEC.` values remain.
+
+Never silently treat an unrecognized encrypted value as plaintext.
+
+## Update JSON Fields
+
+The old `String` and `Int` aliases are replaced by instance-bound values. Configure each field before unmarshalling:
+
+```go
+type Config struct {
+	Secret secure.EncryptedString `json:"secret"`
+}
+
+func decodeConfig(data []byte, cipher secure.Codec) (Config, error) {
+	secret, err := secure.NewEncryptedString(cipher, "")
+	if err != nil {
+		return Config{}, err
+	}
+
+	cfg := Config{Secret: secret}
+	err = json.Unmarshal(data, &cfg)
+	return cfg, err
+}
+```
+
+Access the plaintext through `Value` and update it through `Set`:
+
+```go
+current := cfg.Secret.Value()
+cfg.Secret.Set("replacement")
+```
+
+`NewEncryptedInt` follows the same pattern. Plaintext JSON is rejected by default. If existing configuration files contain plaintext during migration, explicitly opt in:
+
+```go
+secret, err := secure.NewEncryptedString(
+	cipher,
+	"",
+	secure.WithPlaintextJSONMigration(),
+)
+```
+
+The next JSON marshal encrypts the migrated value.
+
+## Replace Stream Encryption
+
+Encrypt streams through the cipher instance:
+
+```go
+writer, err := cipher.NewEncryptWriter(destination)
+if err != nil {
+	return err
+}
+if _, err := io.Copy(writer, source); err != nil {
+	return err
+}
+if err := writer.Close(); err != nil {
+	return err
+}
+```
+
+`Close` is mandatory because it writes the authenticated final record. Decrypt with:
+
+```go
+reader, err := cipher.NewDecryptReader(encryptedSource)
+if err != nil {
+	return err
+}
+_, err = io.Copy(destination, reader)
+```
+
+Discard partial output if stream decryption returns an error.
+
+V2 cannot directly read v1 AES-CFB streams. Migrate them with a temporary tool that imports v0.0.4 under an alias, decrypts using the original key and IV, and writes the plaintext through a v2 authenticated writer. Do not retain CFB support in the production path.
+
+## Validate the Rollout
+
+Before deployment, verify that:
+
+- Representative default- and custom-salt `SEC.` values migrate successfully.
+- Wrong keys, passwords, or associated data return an authentication error.
+- Plaintext JSON is accepted only where migration mode was deliberately enabled.
+- Every encrypting stream writer is closed and truncated streams are rejected.
+- Persisted data is progressively rewritten with the `SEC2.` prefix.
+- Tests run with `go test ./... -race`.

--- a/errors.go
+++ b/errors.go
@@ -1,61 +1,12 @@
 package secure
 
-import (
-	"bytes"
-	"errors"
-)
+import "errors"
 
 var (
-	ErrNotEncrypted    = errors.New("string not encrypted")
-	ErrNoEncryptionKey = errors.New("no encryption gKey")
-	ErrDataOverflow    = errors.New("additional data overflow")
-	ErrInvalidKeySz    = errors.New("invalid key size, len(key)%8!=0")
+	ErrInvalidEnvelope    = errors.New("secure: invalid envelope")
+	ErrAuthentication     = errors.New("secure: authentication failed")
+	ErrUnsupportedVersion = errors.New("secure: unsupported envelope version")
+	ErrLimitExceeded      = errors.New("secure: configured limit exceeded")
+	ErrTruncated          = errors.New("secure: encrypted stream truncated")
+	ErrUnconfigured       = errors.New("secure: value is not configured")
 )
-
-// CipherError indicates that there was an error during decrypting of
-// ciphertext.
-type CipherError struct {
-	Err error
-}
-
-func (e *CipherError) Error() string {
-	return e.Err.Error()
-}
-
-func (e *CipherError) Unwrap() error {
-	return e.Err
-}
-
-func (e *CipherError) Is(target error) bool {
-	t, ok := target.(*CipherError)
-	if !ok {
-		return false
-	}
-	return e.Err.Error() == t.Err.Error()
-}
-
-type CorruptError struct {
-	Value []byte
-}
-
-func (e *CorruptError) Error() string {
-	return "corrupt packed data"
-}
-
-func (e *CorruptError) Is(target error) bool {
-	t, ok := target.(*CorruptError)
-	if !ok {
-		return false
-	}
-	return bytes.Equal(t.Value, e.Value)
-}
-
-// IsDecipherError returns true if there was a decryption error or corrupt data
-// error and false if it's a different kind of error.
-func IsDecipherError(err error) bool {
-	switch err.(type) {
-	case *CipherError, *CorruptError:
-		return true
-	}
-	return false
-}

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/rusq/secure/v2
 go 1.25.0
 
 require golang.org/x/crypto v0.54.0
+
+require golang.org/x/sys v0.47.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rusq/secure
+module github.com/rusq/secure/v2
 
 go 1.25.0
 

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
 golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/int.go
+++ b/int.go
@@ -2,44 +2,78 @@ package secure
 
 import (
 	"bytes"
-	"fmt"
+	"encoding/json"
 	"strconv"
 )
 
-// Int is an encrypted integer.
-type Int int
-
-func (ei Int) String() string {
-	return strconv.Itoa(int(ei))
+// EncryptedInt is an instance-bound encrypted JSON integer encoded as a string.
+type EncryptedInt struct {
+	codec          Codec
+	value          int
+	allowPlaintext bool
 }
 
-func (ei Int) MarshalJSON() ([]byte, error) {
-	data, err := Encrypt(ei.String())
-	return []byte(`"` + data + `"`), err
+// NewEncryptedInt creates a configured encrypted JSON integer.
+func NewEncryptedInt(codec Codec, value int, opts ...JSONOption) (EncryptedInt, error) {
+	if codec == nil {
+		return EncryptedInt{}, ErrUnconfigured
+	}
+	cfg, err := applyJSONOptions(opts)
+	if err != nil {
+		return EncryptedInt{}, err
+	}
+	return EncryptedInt{codec: codec, value: value, allowPlaintext: cfg.allowPlaintext}, nil
 }
 
-func (ei *Int) UnmarshalJSON(b []byte) error {
-	b = bytes.Trim(b, `"`)
-	if len(b) == 0 {
-		*ei = 0
+// Value returns the decrypted integer.
+func (i EncryptedInt) Value() int { return i.value }
+
+// Set replaces the plaintext integer.
+func (i *EncryptedInt) Set(value int) { i.value = value }
+
+func (i EncryptedInt) String() string { return strconv.Itoa(i.value) }
+
+func (i EncryptedInt) MarshalJSON() ([]byte, error) {
+	if i.codec == nil {
+		return nil, ErrUnconfigured
+	}
+	envelope, err := i.codec.Seal([]byte(strconv.Itoa(i.value)), nil)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(envelope)
+}
+
+func (i *EncryptedInt) UnmarshalJSON(data []byte) error {
+	if i == nil || i.codec == nil {
+		return ErrUnconfigured
+	}
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return ErrInvalidEnvelope
+	}
+	var encoded string
+	if err := json.Unmarshal(data, &encoded); err != nil {
+		return err
+	}
+	if len(encoded) < len(prefix) || encoded[:len(prefix)] != prefix {
+		if !i.allowPlaintext {
+			return ErrInvalidEnvelope
+		}
+		value, err := strconv.Atoi(encoded)
+		if err != nil {
+			return err
+		}
+		i.value = value
 		return nil
 	}
-	pt, err := Decrypt(string(b))
-	if err != nil {
-		if err == ErrNotEncrypted {
-			val, err := strconv.Atoi(string(b))
-			if err != nil {
-				return err
-			}
-			*ei = Int(val)
-			return nil
-		}
-		return fmt.Errorf("%w, while decrypting: %q", err, string(b))
-	}
-	val, err := strconv.Atoi(pt)
+	plaintext, err := i.codec.Open(encoded, nil)
 	if err != nil {
 		return err
 	}
-	*ei = Int(val)
+	value, err := strconv.Atoi(string(plaintext))
+	if err != nil {
+		return ErrInvalidEnvelope
+	}
+	i.value = value
 	return nil
 }

--- a/int_test.go
+++ b/int_test.go
@@ -1,45 +1,65 @@
 package secure
 
 import (
+	"encoding/json"
+	"errors"
 	"math"
 	"testing"
 )
 
-func TestInt_MarshalUnmarshalJSON(t *testing.T) {
-	s := newTestKeySentinel()
-	defer s.Reset()
-
-	testcases := []int{123, -1, math.MaxInt}
-	for _, tc := range testcases {
-		val := Int(tc)
-		data, err := val.MarshalJSON()
+func TestEncryptedIntJSON(t *testing.T) {
+	c, _ := NewCipher(testKey)
+	for _, input := range []int{0, -1, 42, math.MaxInt} {
+		value, _ := NewEncryptedInt(c, input)
+		data, err := json.Marshal(value)
 		if err != nil {
 			t.Fatal(err)
 		}
-		var got Int
-		if err := got.UnmarshalJSON(data); err != nil {
+		decoded, _ := NewEncryptedInt(c, 0)
+		if err := json.Unmarshal(data, &decoded); err != nil {
 			t.Fatal(err)
+		}
+		if decoded.Value() != input {
+			t.Fatalf("got %d, want %d", decoded.Value(), input)
+		}
+		decoded.Set(7)
+		if decoded.String() != "7" {
+			t.Fatalf("Set failed: %q", decoded.String())
 		}
 	}
 }
 
-func FuzzMarshalUnmarshalJSON(f *testing.F) {
-	s := newTestKeySentinel()
-	defer s.Reset()
-
-	testcases := []int{123, -1, math.MaxInt}
-	for _, tc := range testcases {
-		f.Add(tc)
+func TestEncryptedIntMigrationAndValidation(t *testing.T) {
+	c, _ := NewCipher(testKey)
+	strict, _ := NewEncryptedInt(c, 0)
+	if err := json.Unmarshal([]byte(`"12"`), &strict); !errors.Is(err, ErrInvalidEnvelope) {
+		t.Fatalf("strict error = %v", err)
 	}
-	f.Fuzz(func(t *testing.T, input int) {
-		val := Int(input)
-		data, err := val.MarshalJSON()
-		if err != nil {
-			t.Fatal(err)
-		}
-		var got Int
-		if err := got.UnmarshalJSON(data); err != nil {
-			t.Fatal(err)
-		}
-	})
+	migration, _ := NewEncryptedInt(c, 0, WithPlaintextJSONMigration())
+	if err := json.Unmarshal([]byte(`"-12"`), &migration); err != nil || migration.Value() != -12 {
+		t.Fatalf("migration = %d, %v", migration.Value(), err)
+	}
+	if err := json.Unmarshal([]byte(`"bad"`), &migration); err == nil {
+		t.Fatal("accepted invalid integer")
+	}
+	if err := json.Unmarshal([]byte(`null`), &migration); !errors.Is(err, ErrInvalidEnvelope) {
+		t.Fatalf("null error = %v", err)
+	}
+	if _, err := NewEncryptedInt(nil, 0); !errors.Is(err, ErrUnconfigured) {
+		t.Fatalf("constructor error = %v", err)
+	}
+	if _, err := NewEncryptedInt(c, 0, nil); err == nil {
+		t.Fatal("accepted nil JSON option")
+	}
+	var unconfigured EncryptedInt
+	if _, err := json.Marshal(unconfigured); !errors.Is(err, ErrUnconfigured) {
+		t.Fatalf("marshal error = %v", err)
+	}
+	if err := json.Unmarshal([]byte(`"1"`), &unconfigured); !errors.Is(err, ErrUnconfigured) {
+		t.Fatalf("unmarshal error = %v", err)
+	}
+	invalidEnvelope, _ := c.EncryptString("not an integer")
+	if err := json.Unmarshal([]byte(`"`+invalidEnvelope+`"`), &strict); !errors.Is(err, ErrInvalidEnvelope) {
+		t.Fatalf("invalid encrypted integer error = %v", err)
+	}
 }

--- a/legacy.go
+++ b/legacy.go
@@ -1,0 +1,162 @@
+package secure
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha512"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+const legacySaltBase64 = "UfzY+auFk13ShS54P4A6zhnxIHUq3Xtc5hfbS3LHgwYQkXAzQg11+bgUOVrPrmrsfToqh/iGqOolfrX5YeilXiAvopmFo8zNXDkbbRsXqbTrld37vjwsO+l9XT54NyPapTXYNqdC1ts4uhcSjHaDONgjAjgm4+fiXsvJkNJGJ4R3QWu1ekpPRaqrUKdYNeipJ8G4qTIDAj0Zd1rSDFIIAfq5sob9JHPDOd5PhpMZ19VlAPEtDG88IdDGJ5kFGXwNVzNPjC9yl1r6CFFRvFbUxO0B6+JqgsZMCXbj+ofi12gTpc8yohZsU1At0ljkZxh7ioTjpEkUZNUGaMdFaOtKsA=="
+
+type legacyConfig struct {
+	salt       []byte
+	iterations int
+	prefix     string
+	encoding   *base64.Encoding
+	maxSize    int
+}
+
+// LegacyOption configures read-only migration from v1 ciphertext.
+type LegacyOption func(*legacyConfig) error
+
+func defaultLegacyConfig() legacyConfig {
+	salt, _ := base64.StdEncoding.DecodeString(legacySaltBase64)
+	return legacyConfig{salt: salt, iterations: 4096, prefix: "SEC.", encoding: base64.URLEncoding, maxSize: defaultMaxEnvelope}
+}
+
+// WithLegacySalt selects the salt used to derive a historical v1 key.
+func WithLegacySalt(salt []byte) LegacyOption {
+	return func(c *legacyConfig) error {
+		if len(salt) == 0 {
+			return errors.New("secure: empty legacy salt")
+		}
+		c.salt = append([]byte(nil), salt...)
+		return nil
+	}
+}
+
+// WithLegacyIterations selects the historical PBKDF2 iteration count.
+func WithLegacyIterations(iterations int) LegacyOption {
+	return func(c *legacyConfig) error {
+		if iterations <= 0 || iterations > 100_000_000 {
+			return fmt.Errorf("%w: invalid legacy iteration count", ErrLimitExceeded)
+		}
+		c.iterations = iterations
+		return nil
+	}
+}
+
+// WithLegacyPrefix selects a custom historical armor prefix.
+func WithLegacyPrefix(prefix string) LegacyOption {
+	return func(c *legacyConfig) error {
+		if prefix == "" {
+			return errors.New("secure: empty legacy prefix")
+		}
+		c.prefix = prefix
+		return nil
+	}
+}
+
+// WithLegacyEncoding selects a custom historical base64 encoding.
+func WithLegacyEncoding(encoding *base64.Encoding) LegacyOption {
+	return func(c *legacyConfig) error {
+		if encoding == nil {
+			return errors.New("secure: nil legacy encoding")
+		}
+		c.encoding = encoding
+		return nil
+	}
+}
+
+// WithLegacyMaxEnvelopeSize bounds decoded historical ciphertext.
+func WithLegacyMaxEnvelopeSize(n int) LegacyOption {
+	return func(c *legacyConfig) error {
+		if n < 32 {
+			return ErrLimitExceeded
+		}
+		c.maxSize = n
+		return nil
+	}
+}
+
+func applyLegacyOptions(opts []LegacyOption) (legacyConfig, error) {
+	cfg := defaultLegacyConfig()
+	for _, opt := range opts {
+		if opt == nil {
+			return legacyConfig{}, fmt.Errorf("%w: nil legacy option", ErrInvalidEnvelope)
+		}
+		if err := opt(&cfg); err != nil {
+			return legacyConfig{}, err
+		}
+	}
+	return cfg, nil
+}
+
+// OpenLegacy decrypts a v1 SEC. envelope with an already-derived AES-256 key.
+func OpenLegacy(envelope string, key []byte, opts ...LegacyOption) ([]byte, error) {
+	if len(key) != keySize {
+		return nil, fmt.Errorf("secure: key must be %d bytes", keySize)
+	}
+	cfg, err := applyLegacyOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+	return openLegacy(envelope, key, cfg)
+}
+
+// OpenLegacyWithPassphrase derives the historical PBKDF2-SHA512 key and
+// decrypts a v1 SEC. envelope.
+func OpenLegacyWithPassphrase(envelope string, passphrase []byte, opts ...LegacyOption) ([]byte, error) {
+	if len(passphrase) == 0 {
+		return nil, errors.New("secure: empty passphrase")
+	}
+	cfg, err := applyLegacyOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+	key := pbkdf2.Key(passphrase, cfg.salt, cfg.iterations, keySize, sha512.New)
+	return openLegacy(envelope, key, cfg)
+}
+
+func openLegacy(envelope string, key []byte, cfg legacyConfig) ([]byte, error) {
+	envelope = strings.TrimSpace(envelope)
+	if !strings.HasPrefix(envelope, cfg.prefix) {
+		return nil, ErrInvalidEnvelope
+	}
+	encoded := envelope[len(cfg.prefix):]
+	if cfg.encoding.DecodedLen(len(encoded)) > cfg.maxSize {
+		return nil, ErrLimitExceeded
+	}
+	packed, err := cfg.encoding.DecodeString(encoded)
+	if err != nil || len(packed) < 1 {
+		return nil, ErrInvalidEnvelope
+	}
+	dataLen := int(packed[0])
+	const nonceSize = 12
+	if dataLen > len(packed)-1-nonceSize-16 {
+		return nil, ErrInvalidEnvelope
+	}
+	nonceStart := 1 + dataLen
+	nonce := packed[nonceStart : nonceStart+nonceSize]
+	ciphertext := packed[nonceStart+nonceSize:]
+	additionalData := packed[1:nonceStart]
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	plaintext, err := aead.Open(nil, nonce, ciphertext, additionalData)
+	if err != nil {
+		return nil, ErrAuthentication
+	}
+	return plaintext, nil
+}

--- a/secure.go
+++ b/secure.go
@@ -76,6 +76,13 @@ type Cipher struct {
 	cfg config
 }
 
+func (c *Cipher) validate() error {
+	if c == nil || c.cfg.maxEnvelope == 0 || c.cfg.rand == nil {
+		return ErrUnconfigured
+	}
+	return nil
+}
+
 // NewCipher creates a key-based encryption context. key must contain 32 bytes.
 func NewCipher(key []byte, opts ...Option) (*Cipher, error) {
 	if len(key) != keySize {
@@ -143,6 +150,13 @@ type PasswordCipher struct {
 	cfg        passwordConfig
 }
 
+func (p *PasswordCipher) validate() error {
+	if p == nil || len(p.passphrase) == 0 || p.cfg.maxEnvelope == 0 || p.cfg.rand == nil {
+		return ErrUnconfigured
+	}
+	return nil
+}
+
 // NewPasswordCipher creates a password-based encryption context.
 func NewPasswordCipher(passphrase []byte, opts ...PasswordOption) (*PasswordCipher, error) {
 	if len(passphrase) == 0 {
@@ -162,11 +176,17 @@ func NewPasswordCipher(passphrase []byte, opts ...PasswordOption) (*PasswordCiph
 
 // Seal encrypts plaintext and authenticates additionalData without storing it.
 func (c *Cipher) Seal(plaintext, additionalData []byte) (string, error) {
+	if err := c.validate(); err != nil {
+		return "", err
+	}
 	return sealWithKey(c.key[:], modeKey, nil, plaintext, additionalData, c.cfg)
 }
 
 // Open authenticates and decrypts a key-based SEC2 envelope.
 func (c *Cipher) Open(envelope string, additionalData []byte) ([]byte, error) {
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
 	if len(additionalData) > c.cfg.maxEnvelope {
 		return nil, ErrLimitExceeded
 	}
@@ -193,6 +213,9 @@ func (c *Cipher) DecryptString(envelope string) (string, error) {
 
 // Seal encrypts plaintext using a fresh salt and Argon2id-derived key.
 func (p *PasswordCipher) Seal(plaintext, additionalData []byte) (string, error) {
+	if err := p.validate(); err != nil {
+		return "", err
+	}
 	if err := checkSealSize(2+4+4+1+saltSize, len(plaintext), len(additionalData), p.cfg.maxEnvelope); err != nil {
 		return "", err
 	}
@@ -207,6 +230,9 @@ func (p *PasswordCipher) Seal(plaintext, additionalData []byte) (string, error) 
 
 // Open authenticates and decrypts a password-based SEC2 envelope.
 func (p *PasswordCipher) Open(envelope string, additionalData []byte) ([]byte, error) {
+	if err := p.validate(); err != nil {
+		return nil, err
+	}
 	if len(additionalData) > p.cfg.maxEnvelope {
 		return nil, ErrLimitExceeded
 	}
@@ -307,7 +333,7 @@ func parseEnvelope(envelope string, limit int) (header, nonce, ciphertext []byte
 	case modePassword:
 		headerLen += 4 + 4 + 1 + saltSize
 	default:
-		return nil, nil, nil, ErrUnsupportedVersion
+		return nil, nil, nil, ErrInvalidEnvelope
 	}
 	const nonceLen = 12
 	if len(packed) < headerLen+nonceLen+16 {

--- a/secure.go
+++ b/secure.go
@@ -1,313 +1,341 @@
-// Package secure provides simple convenience encryption and decryption
-// functions.
-//
-// It should not be used to encrypt critical information in open source
-// projects, where the salt might be known to attaker.
-//
-// It uses the standard Go runtime AES-256 block cipher with GCM.
-//
-// Encryption key is a 256-bit value (32 bytes).
-//
-// The default "Salt" is a fixed 256 byte array of pseudo-random values, taken
-// from /dev/urandom.
-//
-// Then additional data, nonce and ciphertext are packed into the following
-// sequence of bytes:
-//
-//   |_|__...__|_________|__...__|
-//    ^    ^        ^        ^
-//    |    |        |        +- ciphertext, n bytes.
-//    |    |        +---------- nonce, (nonceSz bytes)
-//    |    +------------------- additinal data, m bytes, (maxDataSz bytes),
-//    +------------------------ additional data length value (adlSz bytes).
-//
-// After this, packed byte sequence is armoured with base64 and the signature
-// prefix added to it to distinct it from the plain text.
+// Package secure provides versioned, authenticated encryption for byte
+// slices, strings, JSON values, and streams.
 package secure
 
 import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
-	"crypto/sha512"
 	"encoding/base64"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 
-	"golang.org/x/crypto/pbkdf2"
+	"golang.org/x/crypto/argon2"
 )
 
 const (
-	nonceSz   = 12                // bytes, nonce sz
-	keyBits   = 256               // encryption gKey size.
-	keySz     = keyBits >> 3      // bytes, gKey size
-	adlSz     = 1                 // bytes, size of additional data length field
-	maxDataSz = 1<<(adlSz<<3) - 1 // bytes, max additional data size (this is the maximum that can fit into (adlSz) bytes)
+	prefix             = "SEC2."
+	envelopeVersion    = 2
+	modeKey            = 1
+	modePassword       = 2
+	keySize            = 32
+	saltSize           = 16
+	defaultMaxEnvelope = 16 << 20
+
+	defaultArgonTime    = uint32(3)
+	defaultArgonMemory  = uint32(64 * 1024)
+	defaultArgonThreads = uint8(4)
+	maxArgonTime        = uint32(10)
+	maxArgonMemory      = uint32(256 * 1024)
+	maxArgonThreads     = uint8(16)
 )
 
-var (
-	// used to identify encrypted strings
-	signature = "SEC."
-	// DeriveIter is the number of iterations used to derive the key.
-	DeriveIter = 4096
+// Codec is implemented by encryption contexts usable by the JSON helpers.
+type Codec interface {
+	Seal(plaintext, additionalData []byte) (string, error)
+	Open(envelope string, additionalData []byte) ([]byte, error)
+}
 
-	// salt will be used to XOR the gKey which we generate by padding the
-	// passphrase.  It is advised that caller sets their own salt (BYO) with
-	// SetSalt.
-	salt = []byte{
-		0x51, 0xfc, 0xd8, 0xf9, 0xab, 0x85, 0x93, 0x5d, 0xd2, 0x85, 0x2e, 0x78,
-		0x3f, 0x80, 0x3a, 0xce, 0x19, 0xf1, 0x20, 0x75, 0x2a, 0xdd, 0x7b, 0x5c,
-		0xe6, 0x17, 0xdb, 0x4b, 0x72, 0xc7, 0x83, 0x06, 0x10, 0x91, 0x70, 0x33,
-		0x42, 0x0d, 0x75, 0xf9, 0xb8, 0x14, 0x39, 0x5a, 0xcf, 0xae, 0x6a, 0xec,
-		0x7d, 0x3a, 0x2a, 0x87, 0xf8, 0x86, 0xa8, 0xea, 0x25, 0x7e, 0xb5, 0xf9,
-		0x61, 0xe8, 0xa5, 0x5e, 0x20, 0x2f, 0xa2, 0x99, 0x85, 0xa3, 0xcc, 0xcd,
-		0x5c, 0x39, 0x1b, 0x6d, 0x1b, 0x17, 0xa9, 0xb4, 0xeb, 0x95, 0xdd, 0xfb,
-		0xbe, 0x3c, 0x2c, 0x3b, 0xe9, 0x7d, 0x5d, 0x3e, 0x78, 0x37, 0x23, 0xda,
-		0xa5, 0x35, 0xd8, 0x36, 0xa7, 0x42, 0xd6, 0xdb, 0x38, 0xba, 0x17, 0x12,
-		0x8c, 0x76, 0x83, 0x38, 0xd8, 0x23, 0x02, 0x38, 0x26, 0xe3, 0xe7, 0xe2,
-		0x5e, 0xcb, 0xc9, 0x90, 0xd2, 0x46, 0x27, 0x84, 0x77, 0x41, 0x6b, 0xb5,
-		0x7a, 0x4a, 0x4f, 0x45, 0xaa, 0xab, 0x50, 0xa7, 0x58, 0x35, 0xe8, 0xa9,
-		0x27, 0xc1, 0xb8, 0xa9, 0x32, 0x03, 0x02, 0x3d, 0x19, 0x77, 0x5a, 0xd2,
-		0x0c, 0x52, 0x08, 0x01, 0xfa, 0xb9, 0xb2, 0x86, 0xfd, 0x24, 0x73, 0xc3,
-		0x39, 0xde, 0x4f, 0x86, 0x93, 0x19, 0xd7, 0xd5, 0x65, 0x00, 0xf1, 0x2d,
-		0x0c, 0x6f, 0x3c, 0x21, 0xd0, 0xc6, 0x27, 0x99, 0x05, 0x19, 0x7c, 0x0d,
-		0x57, 0x33, 0x4f, 0x8c, 0x2f, 0x72, 0x97, 0x5a, 0xfa, 0x08, 0x51, 0x51,
-		0xbc, 0x56, 0xd4, 0xc4, 0xed, 0x01, 0xeb, 0xe2, 0x6a, 0x82, 0xc6, 0x4c,
-		0x09, 0x76, 0xe3, 0xfa, 0x87, 0xe2, 0xd7, 0x68, 0x13, 0xa5, 0xcf, 0x32,
-		0xa2, 0x16, 0x6c, 0x53, 0x50, 0x2d, 0xd2, 0x58, 0xe4, 0x67, 0x18, 0x7b,
-		0x8a, 0x84, 0xe3, 0xa4, 0x49, 0x14, 0x64, 0xd5, 0x06, 0x68, 0xc7, 0x45,
-		0x68, 0xeb, 0x4a, 0xb0,
+type config struct {
+	maxEnvelope int
+	rand        io.Reader
+}
+
+// Option configures a Cipher.
+type Option func(*config) error
+
+// WithMaxEnvelopeSize limits the decoded envelope size accepted or produced.
+func WithMaxEnvelopeSize(n int) Option {
+	return func(c *config) error {
+		if n < 64 {
+			return fmt.Errorf("%w: envelope size must be at least 64 bytes", ErrLimitExceeded)
+		}
+		c.maxEnvelope = n
+		return nil
 	}
-)
+}
 
-var b64encoding = base64.URLEncoding
+func newConfig(opts []Option) (config, error) {
+	c := config{maxEnvelope: defaultMaxEnvelope, rand: rand.Reader}
+	for _, opt := range opts {
+		if opt == nil {
+			return config{}, fmt.Errorf("%w: nil option", ErrInvalidEnvelope)
+		}
+		if err := opt(&c); err != nil {
+			return config{}, err
+		}
+	}
+	return c, nil
+}
 
-var gKey []byte
+// Cipher is an immutable AES-256-GCM encryption context.
+type Cipher struct {
+	key [keySize]byte
+	cfg config
+}
 
-// SetGlobalKey sets the global package Key, it doesn't check for key size.
-func SetGlobalKey(k []byte) error {
-	gKey = k
+// NewCipher creates a key-based encryption context. key must contain 32 bytes.
+func NewCipher(key []byte, opts ...Option) (*Cipher, error) {
+	if len(key) != keySize {
+		return nil, fmt.Errorf("secure: key must be %d bytes", keySize)
+	}
+	cfg, err := newConfig(opts)
+	if err != nil {
+		return nil, err
+	}
+	c := &Cipher{cfg: cfg}
+	copy(c.key[:], key)
+	return c, nil
+}
+
+// Argon2Parameters controls password key derivation. Memory is measured in KiB.
+type Argon2Parameters struct {
+	Time    uint32
+	Memory  uint32
+	Threads uint8
+}
+
+func defaultArgon2Parameters() Argon2Parameters {
+	return Argon2Parameters{defaultArgonTime, defaultArgonMemory, defaultArgonThreads}
+}
+
+func validateArgon2(p Argon2Parameters) error {
+	if p.Time < defaultArgonTime || p.Memory < defaultArgonMemory || p.Threads < defaultArgonThreads {
+		return fmt.Errorf("%w: Argon2id parameters are below the security minimum", ErrLimitExceeded)
+	}
+	if p.Time > maxArgonTime || p.Memory > maxArgonMemory || p.Threads > maxArgonThreads {
+		return fmt.Errorf("%w: Argon2id parameters exceed resource limits", ErrLimitExceeded)
+	}
 	return nil
 }
 
-// SetPassphrase allows to set the global passphrase, from which the key is
-// derived.
-func SetPassphrase(b []byte) error {
-	k, err := DeriveKey(b, keySz)
+type passwordConfig struct {
+	config
+	argon Argon2Parameters
+}
+
+// PasswordOption configures a PasswordCipher.
+type PasswordOption func(*passwordConfig) error
+
+// WithPasswordMaxEnvelopeSize sets the decoded envelope limit.
+func WithPasswordMaxEnvelopeSize(n int) PasswordOption {
+	return func(c *passwordConfig) error {
+		return WithMaxEnvelopeSize(n)(&c.config)
+	}
+}
+
+// WithArgon2Parameters raises the Argon2id work factors used for new data.
+func WithArgon2Parameters(p Argon2Parameters) PasswordOption {
+	return func(c *passwordConfig) error {
+		if err := validateArgon2(p); err != nil {
+			return err
+		}
+		c.argon = p
+		return nil
+	}
+}
+
+// PasswordCipher encrypts with a password and a fresh Argon2id salt per item.
+type PasswordCipher struct {
+	passphrase []byte
+	cfg        passwordConfig
+}
+
+// NewPasswordCipher creates a password-based encryption context.
+func NewPasswordCipher(passphrase []byte, opts ...PasswordOption) (*PasswordCipher, error) {
+	if len(passphrase) == 0 {
+		return nil, errors.New("secure: empty passphrase")
+	}
+	cfg := passwordConfig{config: config{maxEnvelope: defaultMaxEnvelope, rand: rand.Reader}, argon: defaultArgon2Parameters()}
+	for _, opt := range opts {
+		if opt == nil {
+			return nil, fmt.Errorf("%w: nil option", ErrInvalidEnvelope)
+		}
+		if err := opt(&cfg); err != nil {
+			return nil, err
+		}
+	}
+	return &PasswordCipher{passphrase: append([]byte(nil), passphrase...), cfg: cfg}, nil
+}
+
+// Seal encrypts plaintext and authenticates additionalData without storing it.
+func (c *Cipher) Seal(plaintext, additionalData []byte) (string, error) {
+	return sealWithKey(c.key[:], modeKey, nil, plaintext, additionalData, c.cfg)
+}
+
+// Open authenticates and decrypts a key-based SEC2 envelope.
+func (c *Cipher) Open(envelope string, additionalData []byte) ([]byte, error) {
+	if len(additionalData) > c.cfg.maxEnvelope {
+		return nil, ErrLimitExceeded
+	}
+	header, nonce, ciphertext, err := parseEnvelope(envelope, c.cfg.maxEnvelope)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return SetGlobalKey(k)
-}
-
-// SetEncoding allows to set the package-wide encoding.  Encoding is used
-// for armoring the ciphertext.
-func SetEncoding(enc *base64.Encoding) {
-	b64encoding = enc
-}
-
-// DeriveKey interpolates the passphrase value to the gKey size and xors it
-// with salt.
-func DeriveKey(pass []byte, keySz int) ([]byte, error) {
-	if len(pass) == 0 {
-		return nil, errors.New("empty passphrase")
+	if header[1] != modeKey {
+		return nil, fmt.Errorf("%w: envelope requires a password", ErrInvalidEnvelope)
 	}
-	if keySz%8 != 0 {
-		return nil, ErrInvalidKeySz
+	return openAEAD(c.key[:], header, nonce, ciphertext, additionalData)
+}
+
+// EncryptString encrypts a UTF-8 string without additional data.
+func (c *Cipher) EncryptString(plaintext string) (string, error) {
+	return c.Seal([]byte(plaintext), nil)
+}
+
+// DecryptString decrypts a UTF-8 string without additional data.
+func (c *Cipher) DecryptString(envelope string) (string, error) {
+	b, err := c.Open(envelope, nil)
+	return string(b), err
+}
+
+// Seal encrypts plaintext using a fresh salt and Argon2id-derived key.
+func (p *PasswordCipher) Seal(plaintext, additionalData []byte) (string, error) {
+	if err := checkSealSize(2+4+4+1+saltSize, len(plaintext), len(additionalData), p.cfg.maxEnvelope); err != nil {
+		return "", err
 	}
-
-	return pbkdf2.Key(pass, salt[:], DeriveIter, keySz, sha512.New), nil
+	salt := make([]byte, saltSize)
+	if _, err := io.ReadFull(p.cfg.rand, salt); err != nil {
+		return "", fmt.Errorf("secure: generate salt: %w", err)
+	}
+	header := passwordHeader(p.cfg.argon, salt)
+	key := argon2.IDKey(p.passphrase, salt, p.cfg.argon.Time, p.cfg.argon.Memory, p.cfg.argon.Threads, keySize)
+	return sealWithKey(key, modePassword, header[2:], plaintext, additionalData, p.cfg.config)
 }
 
-// Encrypt encrypts the plain text password to use in the configuration file
-// with the gKey generated by KeyFn.
-func Encrypt(plaintext string) (string, error) {
-	return encrypt(plaintext, gKey, nil)
+// Open authenticates and decrypts a password-based SEC2 envelope.
+func (p *PasswordCipher) Open(envelope string, additionalData []byte) ([]byte, error) {
+	if len(additionalData) > p.cfg.maxEnvelope {
+		return nil, ErrLimitExceeded
+	}
+	header, nonce, ciphertext, err := parseEnvelope(envelope, p.cfg.maxEnvelope)
+	if err != nil {
+		return nil, err
+	}
+	if header[1] != modePassword || len(header) != 2+4+4+1+saltSize {
+		return nil, fmt.Errorf("%w: envelope does not contain password parameters", ErrInvalidEnvelope)
+	}
+	params := Argon2Parameters{binary.BigEndian.Uint32(header[2:6]), binary.BigEndian.Uint32(header[6:10]), header[10]}
+	if err := validateArgon2(params); err != nil {
+		return nil, err
+	}
+	salt := header[11 : 11+saltSize]
+	key := argon2.IDKey(p.passphrase, salt, params.Time, params.Memory, params.Threads, keySize)
+	return openAEAD(key, header, nonce, ciphertext, additionalData)
 }
 
-// Decrypt attempts to decrypt the string and return the password.
-// In case s is not an encrypted string, ErrNotEncrypted returned along with
-// original string.
-func Decrypt(s string) (string, error) {
-	return decrypt(s, gKey)
+func (p *PasswordCipher) EncryptString(plaintext string) (string, error) {
+	return p.Seal([]byte(plaintext), nil)
 }
 
-// EncryptWithPassphrase encrypts plaintext with the provided passphrase.
-func EncryptWithPassphrase(plaintext string, passphrase []byte) (string, error) {
-	key, err := DeriveKey(passphrase, keySz)
+func (p *PasswordCipher) DecryptString(envelope string) (string, error) {
+	b, err := p.Open(envelope, nil)
+	return string(b), err
+}
+
+func passwordHeader(p Argon2Parameters, salt []byte) []byte {
+	h := make([]byte, 2+4+4+1+saltSize)
+	h[0], h[1] = envelopeVersion, modePassword
+	binary.BigEndian.PutUint32(h[2:6], p.Time)
+	binary.BigEndian.PutUint32(h[6:10], p.Memory)
+	h[10] = p.Threads
+	copy(h[11:], salt)
+	return h
+}
+
+func sealWithKey(key []byte, mode byte, extraHeader, plaintext, additionalData []byte, cfg config) (string, error) {
+	header := append([]byte{envelopeVersion, mode}, extraHeader...)
+	if err := checkSealSize(len(header), len(plaintext), len(additionalData), cfg.maxEnvelope); err != nil {
+		return "", err
+	}
+	block, err := aes.NewCipher(key)
 	if err != nil {
 		return "", err
 	}
-	return encrypt(plaintext, key, nil)
-}
-
-// DecryptWithPassphrase attempts to descrypt string with the provided
-// passphrase.
-func DecryptWithPassphrase(s string, passphrase []byte) (string, error) {
-	key, err := DeriveKey(passphrase, keySz)
+	aead, err := cipher.NewGCM(block)
 	if err != nil {
 		return "", err
 	}
-	return decrypt(s, key)
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := io.ReadFull(cfg.rand, nonce); err != nil {
+		return "", fmt.Errorf("secure: generate nonce: %w", err)
+	}
+	ciphertext := aead.Seal(nil, nonce, plaintext, envelopeAAD(header, additionalData))
+	packedLen := len(header) + len(nonce) + len(ciphertext)
+	if packedLen > cfg.maxEnvelope {
+		return "", ErrLimitExceeded
+	}
+	packed := make([]byte, 0, packedLen)
+	packed = append(packed, header...)
+	packed = append(packed, nonce...)
+	packed = append(packed, ciphertext...)
+	return prefix + base64.RawURLEncoding.EncodeToString(packed), nil
 }
 
-// Encrypt encrypts the plain text password to use in the configuration file.
-func encrypt(plaintext string, key []byte, additionalData []byte) (string, error) {
-	if len(key) == 0 {
-		return "", ErrNoEncryptionKey
+func checkSealSize(headerLen, plaintextLen, additionalDataLen, limit int) error {
+	const gcmOverhead = 16
+	const nonceLen = 12
+	if additionalDataLen > limit || headerLen > limit-nonceLen-gcmOverhead || plaintextLen > limit-headerLen-nonceLen-gcmOverhead {
+		return ErrLimitExceeded
 	}
-	if len(key) != keySz {
-		return "", ErrInvalidKeySz
-	}
-	if len(plaintext) == 0 {
-		return "", errors.New("nothing to encrypt")
-	}
-	if len(additionalData) > maxDataSz {
-		return "", fmt.Errorf("size of additional data can't exceed %d B", maxDataSz)
-	}
-
-	gcm, err := initGCM(key)
-	if err != nil {
-		return "", err
-	}
-
-	nonce := make([]byte, nonceSz)
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return "", err
-	}
-	ciphertext := gcm.Seal(nil, nonce, []byte(plaintext), additionalData)
-
-	// return signature + base64.StdEncoding.EncodeToString(data), nil
-	packed, err := pack(ciphermsg{nonce, ciphertext, additionalData})
-	if err != nil {
-		return "", err
-	}
-
-	return armor(packed), nil
+	return nil
 }
 
-// initGCM initialises the Galois/Counter Mode
-func initGCM(key []byte) (cipher.AEAD, error) {
+func parseEnvelope(envelope string, limit int) (header, nonce, ciphertext []byte, err error) {
+	if len(envelope) < len(prefix) || envelope[:len(prefix)] != prefix {
+		return nil, nil, nil, ErrInvalidEnvelope
+	}
+	encoded := envelope[len(prefix):]
+	if base64.RawURLEncoding.DecodedLen(len(encoded)) > limit {
+		return nil, nil, nil, ErrLimitExceeded
+	}
+	packed, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("%w: invalid base64", ErrInvalidEnvelope)
+	}
+	if len(packed) < 2 || packed[0] != envelopeVersion {
+		if len(packed) > 0 && packed[0] != envelopeVersion {
+			return nil, nil, nil, ErrUnsupportedVersion
+		}
+		return nil, nil, nil, ErrInvalidEnvelope
+	}
+	headerLen := 2
+	switch packed[1] {
+	case modeKey:
+	case modePassword:
+		headerLen += 4 + 4 + 1 + saltSize
+	default:
+		return nil, nil, nil, ErrUnsupportedVersion
+	}
+	const nonceLen = 12
+	if len(packed) < headerLen+nonceLen+16 {
+		return nil, nil, nil, ErrInvalidEnvelope
+	}
+	return packed[:headerLen], packed[headerLen : headerLen+nonceLen], packed[headerLen+nonceLen:], nil
+}
+
+func openAEAD(key, header, nonce, ciphertext, additionalData []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
 	}
-	return cipher.NewGCM(block)
-}
-
-func pack(cm ciphermsg) ([]byte, error) {
-	if len(cm.nonce) == 0 {
-		return nil, errors.New("pack: empty nonce")
-	}
-	if len(cm.ciphertext) == 0 {
-		return nil, errors.New("pack: no ciphertext")
-	}
-	dataLen := len(cm.additionalData)
-	if dataLen > maxDataSz {
-		return nil, ErrDataOverflow
-	}
-
-	packed := make([]byte, nonceSz+len(cm.ciphertext)+1+dataLen)
-	packed[0] = byte(dataLen)
-	if dataLen > 0 {
-		copy(packed[adlSz:], cm.additionalData)
-	}
-	copy(packed[adlSz+dataLen:], cm.nonce)
-	copy(packed[adlSz+dataLen+nonceSz:], cm.ciphertext)
-
-	return packed, nil
-}
-
-func armor(packed []byte) string {
-	return signature + b64encoding.EncodeToString(packed)
-}
-
-func unarmor(s string) ([]byte, error) {
-	sigSz := len(signature)
-	s = strings.TrimSpace(s)
-	if len(s) < sigSz || s[0:sigSz] != signature {
-		return nil, ErrNotEncrypted
-	}
-	packed, err := b64encoding.DecodeString(s[sigSz:])
+	aead, err := cipher.NewGCM(block)
 	if err != nil {
 		return nil, err
 	}
-	return packed, nil
-}
-
-type ciphermsg struct {
-	nonce          []byte
-	ciphertext     []byte
-	additionalData []byte
-}
-
-func unpack(packed []byte) (*ciphermsg, error) {
-	if len(packed) == 0 {
-		return nil, errors.New("unpack: empty input")
-	}
-	var (
-		dataLen   = int(packed[0])
-		payloadSz = len(packed) - adlSz - nonceSz // payload is data + ct size
-	)
-	if dataLen > payloadSz || payloadSz-dataLen == 0 {
-		return nil, &CorruptError{packed}
-	}
-	cm := &ciphermsg{
-		nonce:      packed[adlSz+dataLen : adlSz+dataLen+nonceSz],
-		ciphertext: packed[adlSz+dataLen+nonceSz:],
-	}
-	if dataLen > 0 {
-		cm.additionalData = packed[adlSz : adlSz+dataLen]
-	}
-	return cm, nil
-}
-
-func decrypt(s string, key []byte) (string, error) {
-	packed, err := unarmor(s)
+	plaintext, err := aead.Open(nil, nonce, ciphertext, envelopeAAD(header, additionalData))
 	if err != nil {
-		if err == ErrNotEncrypted {
-			return s, err
-		}
-		return "", err // other error
+		return nil, ErrAuthentication
 	}
-	if len(key) == 0 {
-		return "", ErrNoEncryptionKey
-	}
-	cm, err := unpack(packed)
-	if err != nil {
-		return "", err
-	}
-	aesgcm, err := initGCM(key)
-	if err != nil {
-		return "", err
-	}
-
-	plaintext, err := aesgcm.Open(nil, cm.nonce, cm.ciphertext, cm.additionalData)
-	if err != nil {
-		return "", &CipherError{err}
-	}
-	return string(plaintext), nil
+	return plaintext, nil
 }
 
-// SetSignature allows to set package-wide signature, that is used to identify
-// encrypted strings.
-func SetSignature(s string) {
-	if len(s) == 0 {
-		panic("signature can't be empty")
-	}
-	signature = s
-}
-
-// SetSalt allows to set package-wide salt that will be used with every call.
-// Salt should be a random set of bytes, but should remain the same across the
-// calls and application restarts, so it should be generated in some
-// deterministic way.  It would not be possible to decrypt cipher text with
-// different salt.  It is recommended to use at least 8 bytes of salt.
-//
-// IT IS STRONGLY ADVISED TO USE YOUR OWN SALT.
-//
-func SetSalt(sa []byte) {
-	salt = sa
+func envelopeAAD(header, additionalData []byte) []byte {
+	aad := make([]byte, 4+len(header)+len(additionalData))
+	binary.BigEndian.PutUint32(aad[:4], uint32(len(header)))
+	copy(aad[4:], header)
+	copy(aad[4+len(header):], additionalData)
+	return aad
 }

--- a/secure_test.go
+++ b/secure_test.go
@@ -2,392 +2,259 @@ package secure
 
 import (
 	"bytes"
+	"crypto/sha512"
+	"encoding/base64"
 	"errors"
-	"fmt"
-	"log"
-	"reflect"
+	"strings"
 	"testing"
+
+	"golang.org/x/crypto/pbkdf2"
 )
 
-const (
-	encryptedPlainText = "SEC.AIIPjL0a2HgLgOySAw9fAT6ovih9MfzkMv_pyWmmkA3eBxYbDlLQ"
-)
+var testKey = bytes.Repeat([]byte{0x42}, keySize)
 
-var testPassphrase = []byte{0, 0, 0, 0, 0, 0}
-
-func TestEncryptPlainText(t *testing.T) {
-	out, err := EncryptWithPassphrase("plain text", testPassphrase)
-	if err != nil {
-		fmt.Println("brokeh:", err)
-		return
-	}
-	t.Log(out)
-	// Output:
-}
-
-func testNonce(b byte) []byte {
-	var n = make([]byte, nonceSz)
-	for i := range n {
-		n[i] = b
-	}
-	return n
-}
-
-func Test_deriveKey(t *testing.T) {
-	type args struct {
-		pass []byte
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    []byte
-		wantErr bool
-	}{
-		{"zero", args{testPassphrase},
-			[]byte{0x3c, 0x23, 0x9f, 0xe6, 0x3c, 0x15, 0xe2, 0x58, 0xc3, 0x57, 0xed, 0xf6, 0xe1, 0xed, 0x88, 0xb0, 0xc1, 0xa1, 0x49, 0xdd, 0xef, 0xb8, 0x56, 0x6f, 0x3e, 0xb2, 0x76, 0x2a, 0x8, 0xb8, 0x9, 0x16},
-			false,
-		},
-		{"offset 1",
-			args{[]byte{1, 0, 0, 0, 0, 0}},
-			[]byte{0xad, 0x7, 0xde, 0xbf, 0x54, 0xef, 0x32, 0xee, 0xee, 0xda, 0xb3, 0x3f, 0x1, 0x5f, 0x34, 0xd, 0x20, 0x63, 0x31, 0x67, 0x73, 0xd8, 0xb8, 0x77, 0xba, 0x94, 0xa5, 0x79, 0xaf, 0x26, 0xc2, 0xd0},
-			false,
-		},
-		{"empty pass", args{nil}, nil, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := DeriveKey(tt.args.pass, keySz)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("deriveKey() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("deriveKey() got = %#v, want %#v", got, tt.want)
-			}
-		})
-	}
-}
-
-// to reset it's value.
-type keySentinel struct {
-	oldKey []byte
-}
-
-// newKeySentinel sets the global gKey to the specified value.  Call Reset() on
-// the sentinel to reset the initial variable value.
-func newKeySentinel(k []byte) keySentinel {
-	m := keySentinel{gKey}
-	if err := SetGlobalKey(k); err != nil {
-		panic(err)
-	}
-	return m
-}
-
-// Reset resets the old value of KeyFromHwAddr
-func (m keySentinel) Reset() {
-	if err := SetGlobalKey(m.oldKey); err != nil {
-		log.Printf("this is ok: %s", err)
-	}
-}
-
-// newTestKeySentinel sets the gKey to test password
-func newTestKeySentinel() keySentinel {
-	k, err := DeriveKey(testPassphrase, keySz)
-	if err != nil {
-		panic(err)
-	}
-	return newKeySentinel(k)
-}
-
-func Test_Encryption(t *testing.T) {
-	const wantPT = "plain text"
-
-	m := newTestKeySentinel()
-	defer m.Reset()
-
-	key, err := DeriveKey(testPassphrase, keySz)
+func TestCipherRoundTrip(t *testing.T) {
+	c, err := NewCipher(testKey)
 	if err != nil {
 		t.Fatal(err)
 	}
-	ct, err := encrypt(wantPT, key, []byte("123"))
+	plaintext := []byte("secret value")
+	aad := []byte("configuration/database")
+	envelope, err := c.Seal(plaintext, aad)
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Log(ct)
-	pt, err := decrypt(ct, key)
+	if !strings.HasPrefix(envelope, prefix) {
+		t.Fatalf("unexpected envelope: %q", envelope)
+	}
+	got, err := c.Open(envelope, aad)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(wantPT, pt) {
-		t.Errorf("before/after pt doesn't match: want=%q, got=%q", wantPT, pt)
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("got %q, want %q", got, plaintext)
 	}
-}
+	if _, err := c.Open(envelope, []byte("wrong")); !errors.Is(err, ErrAuthentication) {
+		t.Fatalf("wrong AAD error = %v", err)
+	}
 
-func Test_EncryptDecryptWithPassphrase(t *testing.T) {
-	const wantPT = "plain text"
-
-	ct, err := EncryptWithPassphrase(wantPT, []byte("1234567890"))
+	text, err := c.EncryptString("hello")
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Log(ct)
-	pt, err := DecryptWithPassphrase(ct+"     ", []byte("1234567890"))
+	if got, err := c.DecryptString(text); err != nil || got != "hello" {
+		t.Fatalf("DecryptString() = %q, %v", got, err)
+	}
+}
+
+func TestCipherCopiesKey(t *testing.T) {
+	key := append([]byte(nil), testKey...)
+	c, err := NewCipher(key)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(wantPT, pt) {
-		t.Errorf("before/after pt doesn't match: want=%q, got=%q", wantPT, pt)
+	key[0] ^= 0xff
+	envelope, err := c.EncryptString("copied")
+	if err != nil {
+		t.Fatal(err)
 	}
-
-	// trying to decrypt with different passphrase should return error
-	pt, err = DecryptWithPassphrase(ct, []byte("11:22:33:44:55:66"))
-	if err == nil {
-		t.Errorf("should have failed to decrypt, but did not, pt=%v", pt)
-	}
-}
-
-func TestDecrypt(t *testing.T) {
-	z := newTestKeySentinel()
-	defer z.Reset()
-
-	type args struct {
-		s string
-	}
-
-	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr bool
-	}{
-		{"encrypted password", args{encryptedPlainText}, "plain text", false},
-		{"trim", args{"   " + encryptedPlainText + "\n"}, "plain text", false},
-		{"invalid base64", args{encryptedPlainText[:len(encryptedPlainText)-1]}, "", true},
-		{"non-encrypted password", args{"plain text"}, "plain text", true},
-		{"signature, but non-encrypted (error)", args{signature + "plain text"}, "", true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := Decrypt(tt.args.s)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Decrypt() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("Decrypt() got = %v, want %v", got, tt.want)
-			}
-		})
+	if got, err := c.DecryptString(envelope); err != nil || got != "copied" {
+		t.Fatalf("got %q, %v", got, err)
 	}
 }
 
-var (
-	validPacked = bytesjoin([]byte{3, 1, 2, 3}, testNonce(0xcc), []byte{4, 5, 6})
-	validCm     = ciphermsg{
-		additionalData: []byte{1, 2, 3},
-		nonce:          testNonce(0xcc),
-		ciphertext:     []byte{4, 5, 6},
+func TestCipherRejectsInvalidConfiguration(t *testing.T) {
+	for _, key := range [][]byte{nil, make([]byte, 16), make([]byte, 33)} {
+		if _, err := NewCipher(key); err == nil {
+			t.Fatalf("accepted %d-byte key", len(key))
+		}
 	}
-)
-
-func Test_pack(t *testing.T) {
-	type args struct {
-		cm ciphermsg
+	if _, err := NewCipher(testKey, WithMaxEnvelopeSize(1)); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("limit error = %v", err)
 	}
-	tests := []struct {
-		name    string
-		args    args
-		want    []byte
-		wantErr bool
-	}{
-		{"packing ok",
-			args{validCm},
-			validPacked,
-			false,
-		},
-		{"data too big",
-			args{ciphermsg{
-				additionalData: make([]byte, maxDataSz+1),
-				nonce:          testNonce(0xcc),
-				ciphertext:     []byte{4, 5, 6}}},
-			nil,
-			true,
-		},
-		{"empty additional data",
-			args{ciphermsg{
-				additionalData: nil,
-				nonce:          testNonce(0xcc),
-				ciphertext:     []byte{255, 254, 253},
-			}},
-			bytesjoin([]byte{0}, testNonce(0xcc), []byte{255, 254, 253}),
-			false,
-		},
-		{"empty nonce",
-			args{ciphermsg{
-				additionalData: []byte{1, 2, 3},
-				nonce:          nil,
-				ciphertext:     []byte{255, 254, 253},
-			}},
-			nil,
-			true,
-		},
-		{"empty ct",
-			args{ciphermsg{
-				additionalData: []byte{1, 2, 3},
-				nonce:          testNonce(0xcc),
-				ciphertext:     nil,
-			}},
-			nil,
-			true,
-		},
+	if _, err := NewCipher(testKey, nil); !errors.Is(err, ErrInvalidEnvelope) {
+		t.Fatalf("nil option error = %v", err)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := pack(tt.args.cm)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("pack() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !bytes.Equal(got, tt.want) {
-				t.Errorf("pack() = %v, want %v", got, tt.want)
-			}
-		})
+	if _, err := NewPasswordCipher(nil); err == nil {
+		t.Fatal("accepted empty password")
+	}
+	weak := Argon2Parameters{Time: 2, Memory: defaultArgonMemory, Threads: defaultArgonThreads}
+	if _, err := NewPasswordCipher([]byte("pass"), WithArgon2Parameters(weak)); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("weak Argon2 error = %v", err)
 	}
 }
 
-func Test_unpack(t *testing.T) {
-	type args struct {
-		packed []byte
+func TestEnvelopeTamperingAndValidation(t *testing.T) {
+	c, _ := NewCipher(testKey)
+	envelope, err := c.EncryptString("tamper me")
+	if err != nil {
+		t.Fatal(err)
 	}
-	tests := []struct {
-		name    string
-		args    args
-		want    *ciphermsg
-		wantErr bool
-	}{
-		{"ok",
-			args{validPacked},
-			&validCm,
-			false,
-		},
-		{"empty input", args{}, nil, true},
-		{"invalid data length",
-			args{bytesjoin([]byte{6, 1, 2, 3}, testNonce(0xcc), []byte{4, 5, 6})},
-			nil,
-			true,
-		},
-		{"empty data",
-			args{bytesjoin([]byte{0}, testNonce(0xcc), []byte{4, 5, 6})},
-			&ciphermsg{
-				additionalData: nil,
-				nonce:          testNonce(0xcc),
-				ciphertext:     []byte{4, 5, 6},
-			},
-			false,
-		},
-		{"empty CT",
-			args{bytesjoin([]byte{1, 0xdd}, testNonce(0xcc))},
-			nil,
-			true,
-		},
-		{"empty everything except data",
-			args{[]byte{1, 0xdd}},
-			nil,
-			true,
-		},
-		{"nothing to do",
-			args{[]byte{0}},
-			nil,
-			true,
-		},
+	packed, _ := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(envelope, prefix))
+	for _, offset := range []int{1, 2, len(packed) - 1} {
+		mutated := append([]byte(nil), packed...)
+		mutated[offset] ^= 1
+		candidate := prefix + base64.RawURLEncoding.EncodeToString(mutated)
+		if _, err := c.DecryptString(candidate); err == nil {
+			t.Fatalf("tampering at %d was accepted", offset)
+		}
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := unpack(tt.args.packed)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("unpack() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("unpack() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
-// bytejoin aims  to declutter the bytes.Join call in tests.
-func bytesjoin(bb ...[]byte) []byte {
-	return bytes.Join(bb, []byte{})
-}
-
-func Test_armor(t *testing.T) {
-	type args struct {
-		packed []byte
-	}
-	tests := []struct {
+	cases := []struct {
 		name string
-		args args
-		want string
+		in   string
+		want error
 	}{
-		{"ok", args{validPacked}, signature + "AwECA8zMzMzMzMzMzMzMzAQFBg=="},
-		{"another one", args{}, signature},
+		{"plaintext", "plain", ErrInvalidEnvelope},
+		{"bad base64", prefix + "!", ErrInvalidEnvelope},
+		{"empty payload", prefix, ErrInvalidEnvelope},
+		{"short payload", prefix + base64.RawURLEncoding.EncodeToString([]byte{2, modeKey}), ErrInvalidEnvelope},
+		{"old version", prefix + base64.RawURLEncoding.EncodeToString([]byte{1, modeKey}), ErrUnsupportedVersion},
+		{"unknown mode", prefix + base64.RawURLEncoding.EncodeToString([]byte{2, 99}), ErrUnsupportedVersion},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := armor(tt.args.packed); got != tt.want {
-				t.Errorf("armor() = %v, want %v", got, tt.want)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := c.DecryptString(tc.in)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("error = %v, want %v", err, tc.want)
 			}
 		})
 	}
 }
 
-func Test_unarmor(t *testing.T) {
-	type args struct {
-		s string
+func TestEnvelopeLimit(t *testing.T) {
+	c, err := NewCipher(testKey, WithMaxEnvelopeSize(80))
+	if err != nil {
+		t.Fatal(err)
 	}
-	tests := []struct {
-		name    string
-		args    args
-		want    []byte
-		wantErr bool
-	}{
-		{"plain text", args{"some text"}, nil, true},
-		{"illegal base64", args{signature + "hey you"}, nil, true},
-		{"armored data", args{signature + "AwECA8zMzMzMzMzMzMzMzAQFBg=="}, validPacked, false},
-		{"empty text", args{""}, nil, true},
-		{"trim space", args{"    " + signature + "AwECA8zMzMzMzMzMzMzMzAQFBg==   "}, validPacked, false},
+	if _, err := c.Seal(bytes.Repeat([]byte("x"), 80), nil); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("Seal error = %v", err)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := unarmor(tt.args.s)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("unarmor() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("unarmor() = %v, want %v", got, tt.want)
-			}
-		})
+	oversized := prefix + strings.Repeat("A", 200)
+	if _, err := c.Open(oversized, nil); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("Open error = %v", err)
+	}
+	largeAAD := bytes.Repeat([]byte("a"), 81)
+	if _, err := c.Seal(nil, largeAAD); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("Seal AAD error = %v", err)
+	}
+	if _, err := c.Open(prefix, largeAAD); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("Open AAD error = %v", err)
 	}
 }
 
-func TestIsDecryptError(t *testing.T) {
-	type args struct {
-		err error
+func TestPasswordCipher(t *testing.T) {
+	p, err := NewPasswordCipher([]byte("correct horse battery staple"))
+	if err != nil {
+		t.Fatal(err)
 	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{"cipher", args{&CipherError{nil}}, true},
-		{"corrupt", args{&CorruptError{nil}}, true},
-		{"other", args{errors.New("your shotgun is nearby")}, false},
+	envelope, err := p.EncryptString("password secret")
+	if err != nil {
+		t.Fatal(err)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := IsDecipherError(tt.args.err); got != tt.want {
-				t.Errorf("IsDecryptError() = %v, want %v", got, tt.want)
-			}
-		})
+	if got, err := p.DecryptString(envelope); err != nil || got != "password secret" {
+		t.Fatalf("got %q, %v", got, err)
 	}
+	wrong, _ := NewPasswordCipher([]byte("wrong password"))
+	if _, err := wrong.DecryptString(envelope); !errors.Is(err, ErrAuthentication) {
+		t.Fatalf("wrong password error = %v", err)
+	}
+	if _, err := p.DecryptString(envelope); err != nil {
+		t.Fatal(err)
+	}
+
+	packed, _ := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(envelope, prefix))
+	packed[2] = 0xff // force an excessive time cost without running Argon2
+	bad := prefix + base64.RawURLEncoding.EncodeToString(packed)
+	if _, err := p.DecryptString(bad); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("hostile KDF error = %v", err)
+	}
+}
+
+func TestOpenLegacy(t *testing.T) {
+	const envelope = "SEC.AIIPjL0a2HgLgOySAw9fAT6ovih9MfzkMv_pyWmmkA3eBxYbDlLQ"
+	passphrase := []byte{0, 0, 0, 0, 0, 0}
+	got, err := OpenLegacyWithPassphrase(envelope, passphrase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "plain text" {
+		t.Fatalf("got %q", got)
+	}
+	if _, err := OpenLegacyWithPassphrase(envelope, []byte("wrong")); !errors.Is(err, ErrAuthentication) {
+		t.Fatalf("wrong password error = %v", err)
+	}
+	if _, err := OpenLegacyWithPassphrase("plain", passphrase); !errors.Is(err, ErrInvalidEnvelope) {
+		t.Fatalf("plain error = %v", err)
+	}
+}
+
+func TestLegacyMigrationOptions(t *testing.T) {
+	const envelope = "SEC.AIIPjL0a2HgLgOySAw9fAT6ovih9MfzkMv_pyWmmkA3eBxYbDlLQ"
+	passphrase := []byte{0, 0, 0, 0, 0, 0}
+	cfg := defaultLegacyConfig()
+	key := pbkdf2.Key(passphrase, cfg.salt, cfg.iterations, keySize, sha512.New)
+	if got, err := OpenLegacy(envelope, key); err != nil || string(got) != "plain text" {
+		t.Fatalf("OpenLegacy() = %q, %v", got, err)
+	}
+	packed, _ := base64.URLEncoding.DecodeString(strings.TrimPrefix(envelope, "SEC."))
+	custom := "CUSTOM:" + base64.StdEncoding.EncodeToString(packed)
+	got, err := OpenLegacyWithPassphrase(custom, passphrase,
+		WithLegacySalt(cfg.salt),
+		WithLegacyIterations(4096),
+		WithLegacyPrefix("CUSTOM:"),
+		WithLegacyEncoding(base64.StdEncoding),
+		WithLegacyMaxEnvelopeSize(1024),
+	)
+	if err != nil || string(got) != "plain text" {
+		t.Fatalf("custom legacy = %q, %v", got, err)
+	}
+
+	invalid := []LegacyOption{
+		WithLegacySalt(nil),
+		WithLegacyIterations(0),
+		WithLegacyPrefix(""),
+		WithLegacyEncoding(nil),
+		WithLegacyMaxEnvelopeSize(1),
+		nil,
+	}
+	for i, option := range invalid {
+		if _, err := OpenLegacyWithPassphrase(envelope, passphrase, option); err == nil {
+			t.Fatalf("invalid option %d accepted", i)
+		}
+	}
+	if _, err := OpenLegacy(envelope, make([]byte, 16)); err == nil {
+		t.Fatal("legacy accepted short key")
+	}
+	if _, err := OpenLegacyWithPassphrase(envelope, nil); err == nil {
+		t.Fatal("legacy accepted empty passphrase")
+	}
+}
+
+func TestPasswordOptionsAndModeSeparation(t *testing.T) {
+	p, err := NewPasswordCipher([]byte("password"), WithPasswordMaxEnvelopeSize(1024), WithArgon2Parameters(defaultArgon2Parameters()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewPasswordCipher([]byte("password"), nil); !errors.Is(err, ErrInvalidEnvelope) {
+		t.Fatalf("nil password option = %v", err)
+	}
+	c, _ := NewCipher(testKey)
+	keyEnvelope, _ := c.EncryptString("key")
+	if _, err := p.DecryptString(keyEnvelope); !errors.Is(err, ErrInvalidEnvelope) {
+		t.Fatalf("password opened key envelope: %v", err)
+	}
+	passwordEnvelope, _ := p.EncryptString("password")
+	if _, err := c.DecryptString(passwordEnvelope); !errors.Is(err, ErrInvalidEnvelope) {
+		t.Fatalf("key opened password envelope: %v", err)
+	}
+}
+
+func FuzzOpen(f *testing.F) {
+	c, _ := NewCipher(testKey, WithMaxEnvelopeSize(1024))
+	f.Add("plain")
+	f.Add(prefix)
+	f.Fuzz(func(t *testing.T, input string) {
+		_, _ = c.Open(input, nil)
+	})
 }

--- a/secure_test.go
+++ b/secure_test.go
@@ -110,7 +110,7 @@ func TestEnvelopeTamperingAndValidation(t *testing.T) {
 		{"empty payload", prefix, ErrInvalidEnvelope},
 		{"short payload", prefix + base64.RawURLEncoding.EncodeToString([]byte{2, modeKey}), ErrInvalidEnvelope},
 		{"old version", prefix + base64.RawURLEncoding.EncodeToString([]byte{1, modeKey}), ErrUnsupportedVersion},
-		{"unknown mode", prefix + base64.RawURLEncoding.EncodeToString([]byte{2, 99}), ErrUnsupportedVersion},
+		{"unknown mode", prefix + base64.RawURLEncoding.EncodeToString([]byte{2, 99}), ErrInvalidEnvelope},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/stream.go
+++ b/stream.go
@@ -21,6 +21,9 @@ const (
 // NewEncryptWriter returns an authenticated streaming writer. Close must be
 // called to write the authenticated final record.
 func (c *Cipher) NewEncryptWriter(w io.Writer) (io.WriteCloser, error) {
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
 	if w == nil {
 		return nil, errors.New("secure: nil writer")
 	}
@@ -39,6 +42,9 @@ func (c *Cipher) NewEncryptWriter(w io.Writer) (io.WriteCloser, error) {
 
 // NewDecryptReader reads and authenticates a key-based stream.
 func (c *Cipher) NewDecryptReader(r io.Reader) (io.Reader, error) {
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
 	header, salt, _, err := readStreamHeader(r, modeKey)
 	if err != nil {
 		return nil, err
@@ -51,6 +57,9 @@ func (c *Cipher) NewDecryptReader(r io.Reader) (io.Reader, error) {
 }
 
 func (p *PasswordCipher) NewEncryptWriter(w io.Writer) (io.WriteCloser, error) {
+	if err := p.validate(); err != nil {
+		return nil, err
+	}
 	if w == nil {
 		return nil, errors.New("secure: nil writer")
 	}
@@ -70,6 +79,9 @@ func (p *PasswordCipher) NewEncryptWriter(w io.Writer) (io.WriteCloser, error) {
 }
 
 func (p *PasswordCipher) NewDecryptReader(r io.Reader) (io.Reader, error) {
+	if err := p.validate(); err != nil {
+		return nil, err
+	}
 	header, salt, params, err := readStreamHeader(r, modePassword)
 	if err != nil {
 		return nil, err

--- a/stream.go
+++ b/stream.go
@@ -3,39 +3,302 @@ package secure
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
 	"io"
+
+	"golang.org/x/crypto/argon2"
+	"golang.org/x/crypto/hkdf"
 )
 
-// NewWriter returns a StreamWriter, initialised with the global package key,
-// and the provided initialisation vector.  Key can be set with SetKey.
-func NewWriter(w io.Writer, iv [aes.BlockSize]byte) (*cipher.StreamWriter, error) {
-	return NewWriterWithKey(w, gKey, iv)
+const (
+	streamMagic     = "SECS2"
+	streamChunkSize = 64 << 10
+	streamFinal     = byte(1)
+)
+
+// NewEncryptWriter returns an authenticated streaming writer. Close must be
+// called to write the authenticated final record.
+func (c *Cipher) NewEncryptWriter(w io.Writer) (io.WriteCloser, error) {
+	if w == nil {
+		return nil, errors.New("secure: nil writer")
+	}
+	salt := make([]byte, saltSize)
+	if _, err := io.ReadFull(c.cfg.rand, salt); err != nil {
+		return nil, err
+	}
+	header := append([]byte(streamMagic), modeKey)
+	header = append(header, salt...)
+	key, err := deriveStreamKey(c.key[:], salt)
+	if err != nil {
+		return nil, err
+	}
+	return newEncryptWriter(w, key, header)
 }
 
-// NewWriter returns a StreamReader, initialised with the global package key,
-// and the provided initialisation vector.  Key can be set with SetKey.
-func NewReader(r io.Reader, iv [aes.BlockSize]byte) (*cipher.StreamReader, error) {
-	return NewReaderWithKey(r, gKey, iv)
+// NewDecryptReader reads and authenticates a key-based stream.
+func (c *Cipher) NewDecryptReader(r io.Reader) (io.Reader, error) {
+	header, salt, _, err := readStreamHeader(r, modeKey)
+	if err != nil {
+		return nil, err
+	}
+	key, err := deriveStreamKey(c.key[:], salt)
+	if err != nil {
+		return nil, err
+	}
+	return newDecryptReader(r, key, header)
 }
 
-// NewWriterWithKey returns a new StreamWriter initialised with key and an
-// initialisation vector.
-func NewWriterWithKey(w io.Writer, key []byte, iv [aes.BlockSize]byte) (*cipher.StreamWriter, error) {
+func (p *PasswordCipher) NewEncryptWriter(w io.Writer) (io.WriteCloser, error) {
+	if w == nil {
+		return nil, errors.New("secure: nil writer")
+	}
+	salt := make([]byte, saltSize)
+	if _, err := io.ReadFull(p.cfg.rand, salt); err != nil {
+		return nil, err
+	}
+	header := append([]byte(streamMagic), modePassword)
+	params := make([]byte, 9)
+	binary.BigEndian.PutUint32(params[:4], p.cfg.argon.Time)
+	binary.BigEndian.PutUint32(params[4:8], p.cfg.argon.Memory)
+	params[8] = p.cfg.argon.Threads
+	header = append(header, params...)
+	header = append(header, salt...)
+	key := argon2.IDKey(p.passphrase, salt, p.cfg.argon.Time, p.cfg.argon.Memory, p.cfg.argon.Threads, keySize)
+	return newEncryptWriter(w, key, header)
+}
+
+func (p *PasswordCipher) NewDecryptReader(r io.Reader) (io.Reader, error) {
+	header, salt, params, err := readStreamHeader(r, modePassword)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateArgon2(params); err != nil {
+		return nil, err
+	}
+	key := argon2.IDKey(p.passphrase, salt, params.Time, params.Memory, params.Threads, keySize)
+	return newDecryptReader(r, key, header)
+}
+
+func deriveStreamKey(master, salt []byte) ([]byte, error) {
+	r := hkdf.New(sha256.New, master, salt, []byte("github.com/rusq/secure/v2 stream key"))
+	key := make([]byte, keySize)
+	_, err := io.ReadFull(r, key)
+	return key, err
+}
+
+func readStreamHeader(r io.Reader, wantMode byte) ([]byte, []byte, Argon2Parameters, error) {
+	if r == nil {
+		return nil, nil, Argon2Parameters{}, errors.New("secure: nil reader")
+	}
+	base := make([]byte, len(streamMagic)+1)
+	if _, err := io.ReadFull(r, base); err != nil {
+		return nil, nil, Argon2Parameters{}, ErrTruncated
+	}
+	if string(base[:len(streamMagic)]) != streamMagic || base[len(streamMagic)] != wantMode {
+		return nil, nil, Argon2Parameters{}, ErrInvalidEnvelope
+	}
+	header := append([]byte(nil), base...)
+	var params Argon2Parameters
+	if wantMode == modePassword {
+		encoded := make([]byte, 9)
+		if _, err := io.ReadFull(r, encoded); err != nil {
+			return nil, nil, params, ErrTruncated
+		}
+		header = append(header, encoded...)
+		params = Argon2Parameters{binary.BigEndian.Uint32(encoded[:4]), binary.BigEndian.Uint32(encoded[4:8]), encoded[8]}
+	}
+	salt := make([]byte, saltSize)
+	if _, err := io.ReadFull(r, salt); err != nil {
+		return nil, nil, params, ErrTruncated
+	}
+	header = append(header, salt...)
+	return header, salt, params, nil
+}
+
+func streamAEAD(key []byte) (cipher.AEAD, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
 	}
-	stream := cipher.NewCFBEncrypter(block, iv[:])
-	return &cipher.StreamWriter{S: stream, W: w}, nil
+	return cipher.NewGCM(block)
 }
 
-// NewReaderWithKey returns a new StreamReader initialised with key and an
-// initialisation vector.
-func NewReaderWithKey(r io.Reader, key []byte, iv [aes.BlockSize]byte) (*cipher.StreamReader, error) {
-	block, err := aes.NewCipher(key)
+type encryptWriter struct {
+	w       io.Writer
+	aead    cipher.AEAD
+	header  []byte
+	buffer  []byte
+	counter uint64
+	closed  bool
+	err     error
+}
+
+func newEncryptWriter(w io.Writer, key, header []byte) (*encryptWriter, error) {
+	aead, err := streamAEAD(key)
 	if err != nil {
 		return nil, err
 	}
-	stream := cipher.NewCFBDecrypter(block, iv[:])
-	return &cipher.StreamReader{S: stream, R: r}, nil
+	if err := writeAll(w, header); err != nil {
+		return nil, err
+	}
+	return &encryptWriter{w: w, aead: aead, header: header, buffer: make([]byte, 0, streamChunkSize)}, nil
+}
+
+func (w *encryptWriter) Write(p []byte) (int, error) {
+	if w.closed {
+		return 0, errors.New("secure: write after close")
+	}
+	if w.err != nil {
+		return 0, w.err
+	}
+	written := 0
+	for len(p) > 0 {
+		n := min(len(p), streamChunkSize-len(w.buffer))
+		w.buffer = append(w.buffer, p[:n]...)
+		p = p[n:]
+		written += n
+		if len(w.buffer) == streamChunkSize {
+			if err := w.writeRecord(w.buffer, 0); err != nil {
+				w.err = err
+				return written, err
+			}
+			w.buffer = w.buffer[:0]
+		}
+	}
+	return written, nil
+}
+
+func (w *encryptWriter) Close() error {
+	if w.closed {
+		return w.err
+	}
+	w.closed = true
+	if w.err != nil {
+		return w.err
+	}
+	if len(w.buffer) > 0 {
+		if err := w.writeRecord(w.buffer, 0); err != nil {
+			w.err = err
+			return err
+		}
+	}
+	w.err = w.writeRecord(nil, streamFinal)
+	return w.err
+}
+
+func (w *encryptWriter) writeRecord(plaintext []byte, flags byte) error {
+	if w.counter == ^uint64(0) {
+		return ErrLimitExceeded
+	}
+	recordHeader := make([]byte, 5)
+	binary.BigEndian.PutUint32(recordHeader[:4], uint32(len(plaintext)))
+	recordHeader[4] = flags
+	nonce := streamNonce(w.counter)
+	ciphertext := w.aead.Seal(nil, nonce, plaintext, streamAAD(w.header, w.counter, recordHeader))
+	if err := writeAll(w.w, recordHeader); err != nil {
+		return err
+	}
+	if err := writeAll(w.w, ciphertext); err != nil {
+		return err
+	}
+	w.counter++
+	return nil
+}
+
+type decryptReader struct {
+	r       io.Reader
+	aead    cipher.AEAD
+	header  []byte
+	buffer  []byte
+	counter uint64
+	done    bool
+	err     error
+}
+
+func newDecryptReader(r io.Reader, key, header []byte) (*decryptReader, error) {
+	aead, err := streamAEAD(key)
+	if err != nil {
+		return nil, err
+	}
+	return &decryptReader{r: r, aead: aead, header: header}, nil
+}
+
+func (r *decryptReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	for len(r.buffer) == 0 && !r.done && r.err == nil {
+		r.readRecord()
+	}
+	if len(r.buffer) > 0 {
+		n := copy(p, r.buffer)
+		r.buffer = r.buffer[n:]
+		return n, nil
+	}
+	if r.err != nil {
+		return 0, r.err
+	}
+	return 0, io.EOF
+}
+
+func (r *decryptReader) readRecord() {
+	recordHeader := make([]byte, 5)
+	if _, err := io.ReadFull(r.r, recordHeader); err != nil {
+		r.err = ErrTruncated
+		return
+	}
+	length := binary.BigEndian.Uint32(recordHeader[:4])
+	flags := recordHeader[4]
+	if length > streamChunkSize || flags&^streamFinal != 0 || flags == streamFinal && length != 0 {
+		r.err = ErrInvalidEnvelope
+		return
+	}
+	ciphertext := make([]byte, int(length)+r.aead.Overhead())
+	if _, err := io.ReadFull(r.r, ciphertext); err != nil {
+		r.err = ErrTruncated
+		return
+	}
+	plaintext, err := r.aead.Open(nil, streamNonce(r.counter), ciphertext, streamAAD(r.header, r.counter, recordHeader))
+	if err != nil {
+		r.err = ErrAuthentication
+		return
+	}
+	r.counter++
+	if flags == streamFinal {
+		r.done = true
+		return
+	}
+	r.buffer = plaintext
+}
+
+func streamNonce(counter uint64) []byte {
+	nonce := make([]byte, 12)
+	binary.BigEndian.PutUint64(nonce[4:], counter)
+	return nonce
+}
+
+func streamAAD(header []byte, counter uint64, recordHeader []byte) []byte {
+	aad := make([]byte, 0, len(header)+8+len(recordHeader))
+	aad = append(aad, header...)
+	var count [8]byte
+	binary.BigEndian.PutUint64(count[:], counter)
+	aad = append(aad, count[:]...)
+	aad = append(aad, recordHeader...)
+	return aad
+}
+
+func writeAll(w io.Writer, p []byte) error {
+	for len(p) > 0 {
+		n, err := w.Write(p)
+		if err != nil {
+			return err
+		}
+		if n <= 0 || n > len(p) {
+			return io.ErrShortWrite
+		}
+		p = p[n:]
+	}
+	return nil
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -3,6 +3,7 @@ package secure
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 )
@@ -10,7 +11,7 @@ import (
 func TestAuthenticatedStreamRoundTrip(t *testing.T) {
 	c, _ := NewCipher(testKey)
 	for _, size := range []int{0, 1, streamChunkSize - 1, streamChunkSize, streamChunkSize + 1, 2*streamChunkSize + 17} {
-		t.Run(string(rune(size)), func(t *testing.T) {
+		t.Run(fmt.Sprintf("size=%d", size), func(t *testing.T) {
 			input := bytes.Repeat([]byte{byte(size)}, size)
 			var encrypted bytes.Buffer
 			w, err := c.NewEncryptWriter(&encrypted)
@@ -33,6 +34,63 @@ func TestAuthenticatedStreamRoundTrip(t *testing.T) {
 			}
 			if !bytes.Equal(got, input) {
 				t.Fatalf("got %d bytes, want %d", len(got), len(input))
+			}
+		})
+	}
+}
+
+func TestUnconfiguredCiphers(t *testing.T) {
+	var nilCipher *Cipher
+	var nilPasswordCipher *PasswordCipher
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{"nil Cipher Seal", func() error { _, err := nilCipher.Seal(nil, nil); return err }},
+		{"nil Cipher Open", func() error { _, err := nilCipher.Open("", nil); return err }},
+		{"nil Cipher NewEncryptWriter", func() error { _, err := nilCipher.NewEncryptWriter(io.Discard); return err }},
+		{"nil Cipher NewDecryptReader", func() error { _, err := nilCipher.NewDecryptReader(bytes.NewReader(nil)); return err }},
+		{"zero Cipher Seal", func() error { _, err := new(Cipher).Seal(nil, nil); return err }},
+		{"zero Cipher Open", func() error { _, err := new(Cipher).Open("", nil); return err }},
+		{"zero Cipher NewEncryptWriter", func() error { _, err := new(Cipher).NewEncryptWriter(io.Discard); return err }},
+		{"zero Cipher NewDecryptReader", func() error { _, err := new(Cipher).NewDecryptReader(bytes.NewReader(nil)); return err }},
+		{"nil PasswordCipher Seal", func() error { _, err := nilPasswordCipher.Seal(nil, nil); return err }},
+		{"nil PasswordCipher Open", func() error { _, err := nilPasswordCipher.Open("", nil); return err }},
+		{"nil PasswordCipher NewEncryptWriter", func() error { _, err := nilPasswordCipher.NewEncryptWriter(io.Discard); return err }},
+		{"nil PasswordCipher NewDecryptReader", func() error { _, err := nilPasswordCipher.NewDecryptReader(bytes.NewReader(nil)); return err }},
+		{"zero PasswordCipher Seal", func() error { _, err := new(PasswordCipher).Seal(nil, nil); return err }},
+		{"zero PasswordCipher Open", func() error { _, err := new(PasswordCipher).Open("", nil); return err }},
+		{"zero PasswordCipher NewEncryptWriter", func() error { _, err := new(PasswordCipher).NewEncryptWriter(io.Discard); return err }},
+		{"zero PasswordCipher NewDecryptReader", func() error { _, err := new(PasswordCipher).NewDecryptReader(bytes.NewReader(nil)); return err }},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.call(); !errors.Is(err, ErrUnconfigured) {
+				t.Fatalf("error = %v, want %v", err, ErrUnconfigured)
+			}
+		})
+	}
+}
+
+func TestConfiguredCiphersRejectNilStreams(t *testing.T) {
+	c, _ := NewCipher(testKey)
+	p, _ := NewPasswordCipher([]byte("password"))
+
+	for _, tc := range []struct {
+		name string
+		call func() error
+		want string
+	}{
+		{"Cipher writer", func() error { _, err := c.NewEncryptWriter(nil); return err }, "secure: nil writer"},
+		{"Cipher reader", func() error { _, err := c.NewDecryptReader(nil); return err }, "secure: nil reader"},
+		{"PasswordCipher writer", func() error { _, err := p.NewEncryptWriter(nil); return err }, "secure: nil writer"},
+		{"PasswordCipher reader", func() error { _, err := p.NewDecryptReader(nil); return err }, "secure: nil reader"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.call(); err == nil || err.Error() != tc.want {
+				t.Fatalf("error = %v, want %q", err, tc.want)
 			}
 		})
 	}

--- a/stream_test.go
+++ b/stream_test.go
@@ -2,55 +2,193 @@ package secure
 
 import (
 	"bytes"
-	"crypto/aes"
-	"crypto/rand"
+	"errors"
+	"io"
 	"testing"
 )
 
-var _ = SetPassphrase([]byte{0})
+func TestAuthenticatedStreamRoundTrip(t *testing.T) {
+	c, _ := NewCipher(testKey)
+	for _, size := range []int{0, 1, streamChunkSize - 1, streamChunkSize, streamChunkSize + 1, 2*streamChunkSize + 17} {
+		t.Run(string(rune(size)), func(t *testing.T) {
+			input := bytes.Repeat([]byte{byte(size)}, size)
+			var encrypted bytes.Buffer
+			w, err := c.NewEncryptWriter(&encrypted)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := w.Write(input); err != nil {
+				t.Fatal(err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatal(err)
+			}
+			r, err := c.NewDecryptReader(bytes.NewReader(encrypted.Bytes()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := io.ReadAll(r)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got, input) {
+				t.Fatalf("got %d bytes, want %d", len(got), len(input))
+			}
+		})
+	}
+}
 
-func TestStreamReadWriter(t *testing.T) {
-	const randomBufSz = 512000
-
-	// initialise the initialisation vector with randomness
-	var testIV [aes.BlockSize]byte
-	if _, err := rand.Read(testIV[:]); err != nil {
+func TestStreamDetectsTamperingAndTruncation(t *testing.T) {
+	c, _ := NewCipher(testKey)
+	var encrypted bytes.Buffer
+	w, _ := c.NewEncryptWriter(&encrypted)
+	_, _ = w.Write([]byte("stream secret"))
+	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
-	key, err := DeriveKey([]byte("unittesting"), keySz)
+	original := encrypted.Bytes()
+
+	tampered := append([]byte(nil), original...)
+	tampered[len(tampered)-1] ^= 1
+	r, err := c.NewDecryptReader(bytes.NewReader(tampered))
 	if err != nil {
 		t.Fatal(err)
 	}
+	if _, err := io.ReadAll(r); !errors.Is(err, ErrAuthentication) {
+		t.Fatalf("tamper error = %v", err)
+	}
 
-	// generate test data
-	randomness := make([]byte, randomBufSz)
-	rand.Read(randomness)
+	for _, cut := range []int{1, 5, len(original) - 1} {
+		r, err := c.NewDecryptReader(bytes.NewReader(original[:cut]))
+		if err == nil {
+			_, err = io.ReadAll(r)
+		}
+		if !errors.Is(err, ErrTruncated) {
+			t.Fatalf("cut %d error = %v", cut, err)
+		}
+	}
+}
 
-	// write it to the encryption buffer
-	var buf bytes.Buffer
-	w, err := NewWriterWithKey(&buf, key, testIV)
+func TestStreamWrongKeyAndClose(t *testing.T) {
+	c, _ := NewCipher(testKey)
+	var encrypted bytes.Buffer
+	w, _ := c.NewEncryptWriter(&encrypted)
+	_, _ = w.Write([]byte("data"))
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+	if _, err := w.Write([]byte("late")); err == nil {
+		t.Fatal("write after close succeeded")
+	}
+
+	wrongKey := bytes.Repeat([]byte{0x99}, keySize)
+	wrong, _ := NewCipher(wrongKey)
+	r, err := wrong.NewDecryptReader(bytes.NewReader(encrypted.Bytes()))
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	if _, err = w.Write(randomness); err != nil {
-		t.Errorf("write error: %s", err)
+	if _, err := io.ReadAll(r); !errors.Is(err, ErrAuthentication) {
+		t.Fatalf("wrong key error = %v", err)
 	}
+}
 
-	// read data into output from buffer
-	r, err := NewReaderWithKey(&buf, key, testIV)
+func TestPasswordStream(t *testing.T) {
+	p, _ := NewPasswordCipher([]byte("stream password"))
+	var encrypted bytes.Buffer
+	w, err := p.NewEncryptWriter(&encrypted)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	output := make([]byte, len(randomness))
-	_, err = r.Read(output)
+	_, _ = io.WriteString(w, "password stream")
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	r, err := p.NewDecryptReader(bytes.NewReader(encrypted.Bytes()))
 	if err != nil {
-		t.Errorf("output read error: %s", err)
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(r)
+	if err != nil || string(got) != "password stream" {
+		t.Fatalf("got %q, %v", got, err)
+	}
+}
+
+type shortWriter struct{ remaining int }
+
+func (w *shortWriter) Write(p []byte) (int, error) {
+	if w.remaining == 0 {
+		return 0, io.ErrClosedPipe
+	}
+	n := min(len(p), w.remaining)
+	w.remaining -= n
+	return n, nil
+}
+
+func TestStreamPropagatesWriteFailure(t *testing.T) {
+	c, _ := NewCipher(testKey)
+	w, err := c.NewEncryptWriter(&shortWriter{remaining: len(streamMagic) + 1 + saltSize + 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = w.Write(bytes.Repeat([]byte("x"), streamChunkSize))
+	if err := w.Close(); err == nil {
+		t.Fatal("expected write failure")
+	}
+}
+
+func TestStreamRejectsInvalidHeadersAndRecords(t *testing.T) {
+	c, _ := NewCipher(testKey)
+	if _, err := c.NewEncryptWriter(nil); err == nil {
+		t.Fatal("accepted nil writer")
+	}
+	if _, err := c.NewDecryptReader(nil); err == nil {
+		t.Fatal("accepted nil reader")
+	}
+	if _, err := c.NewDecryptReader(bytes.NewReader([]byte("short"))); !errors.Is(err, ErrTruncated) {
+		t.Fatalf("short header error = %v", err)
+	}
+	badHeader := append([]byte(streamMagic), modePassword)
+	badHeader = append(badHeader, make([]byte, 9+saltSize)...)
+	if _, err := c.NewDecryptReader(bytes.NewReader(badHeader)); !errors.Is(err, ErrInvalidEnvelope) {
+		t.Fatalf("wrong mode error = %v", err)
 	}
 
-	// compare
-	if !bytes.Equal(randomness, output) {
-		t.Fatal("input and output data is different")
+	var encrypted bytes.Buffer
+	w, _ := c.NewEncryptWriter(&encrypted)
+	_, _ = w.Write([]byte("record"))
+	_ = w.Close()
+	headerLen := len(streamMagic) + 1 + saltSize
+	for _, mutate := range []func([]byte){
+		func(b []byte) { b[headerLen] = 0xff },
+		func(b []byte) { b[headerLen+4] = 0x80 },
+		func(b []byte) { b[headerLen+4] = streamFinal },
+	} {
+		data := append([]byte(nil), encrypted.Bytes()...)
+		mutate(data)
+		r, err := c.NewDecryptReader(bytes.NewReader(data))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.ReadAll(r); !errors.Is(err, ErrInvalidEnvelope) {
+			t.Fatalf("invalid record error = %v", err)
+		}
+	}
+}
+
+func TestPasswordStreamRejectsHostileParameters(t *testing.T) {
+	p, _ := NewPasswordCipher([]byte("password"))
+	if _, err := p.NewEncryptWriter(nil); err == nil {
+		t.Fatal("accepted nil writer")
+	}
+	header := append([]byte(streamMagic), modePassword)
+	params := make([]byte, 9)
+	params[0] = 0xff
+	header = append(header, params...)
+	header = append(header, make([]byte, saltSize)...)
+	if _, err := p.NewDecryptReader(bytes.NewReader(header)); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("hostile parameters error = %v", err)
 	}
 }

--- a/string.go
+++ b/string.go
@@ -2,38 +2,94 @@ package secure
 
 import (
 	"bytes"
-	"fmt"
+	"encoding/json"
+	"errors"
 )
 
-// String is a type of encrypted string.  Surprise.
-type String string
-
-func (es String) String() string {
-	return string(es)
+type jsonConfig struct {
+	allowPlaintext bool
 }
 
-func (es String) MarshalJSON() ([]byte, error) {
-	if len(es) == 0 {
-		return []byte(`""`), nil
+// JSONOption configures encrypted JSON values.
+type JSONOption func(*jsonConfig)
+
+// WithPlaintextJSONMigration permits a JSON value to accept plaintext input.
+// Values are still encrypted the next time they are marshaled.
+func WithPlaintextJSONMigration() JSONOption {
+	return func(c *jsonConfig) { c.allowPlaintext = true }
+}
+
+// EncryptedString is an instance-bound encrypted JSON string.
+type EncryptedString struct {
+	codec          Codec
+	value          string
+	allowPlaintext bool
+}
+
+// NewEncryptedString creates a configured encrypted JSON string.
+func NewEncryptedString(codec Codec, value string, opts ...JSONOption) (EncryptedString, error) {
+	if codec == nil {
+		return EncryptedString{}, ErrUnconfigured
 	}
-	data, err := Encrypt(string(es))
-	return []byte(`"` + data + `"`), err
+	cfg, err := applyJSONOptions(opts)
+	if err != nil {
+		return EncryptedString{}, err
+	}
+	return EncryptedString{codec: codec, value: value, allowPlaintext: cfg.allowPlaintext}, nil
 }
 
-func (es *String) UnmarshalJSON(b []byte) error {
-	b = bytes.Trim(b, `"`)
-	if len(b) == 0 {
-		*es = ""
+func applyJSONOptions(opts []JSONOption) (jsonConfig, error) {
+	var cfg jsonConfig
+	for _, opt := range opts {
+		if opt == nil {
+			return jsonConfig{}, errors.New("secure: nil JSON option")
+		}
+		opt(&cfg)
+	}
+	return cfg, nil
+}
+
+// Value returns the decrypted value.
+func (s EncryptedString) Value() string { return s.value }
+
+// Set replaces the plaintext value.
+func (s *EncryptedString) Set(value string) { s.value = value }
+
+func (s EncryptedString) String() string { return s.value }
+
+func (s EncryptedString) MarshalJSON() ([]byte, error) {
+	if s.codec == nil {
+		return nil, ErrUnconfigured
+	}
+	envelope, err := s.codec.Seal([]byte(s.value), nil)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(envelope)
+}
+
+func (s *EncryptedString) UnmarshalJSON(data []byte) error {
+	if s == nil || s.codec == nil {
+		return ErrUnconfigured
+	}
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return ErrInvalidEnvelope
+	}
+	var encoded string
+	if err := json.Unmarshal(data, &encoded); err != nil {
+		return err
+	}
+	if len(encoded) < len(prefix) || encoded[:len(prefix)] != prefix {
+		if !s.allowPlaintext {
+			return ErrInvalidEnvelope
+		}
+		s.value = encoded
 		return nil
 	}
-	pt, err := Decrypt(string(b))
+	plaintext, err := s.codec.Open(encoded, nil)
 	if err != nil {
-		if err == ErrNotEncrypted {
-			*es = String(b)
-			return nil
-		}
-		return fmt.Errorf("%w, while decrypting: %q", err, string(b))
+		return err
 	}
-	*es = String(pt)
+	s.value = string(plaintext)
 	return nil
 }

--- a/string_test.go
+++ b/string_test.go
@@ -1,112 +1,75 @@
 package secure
 
 import (
-	"bytes"
 	"encoding/json"
-	"reflect"
+	"errors"
 	"testing"
 )
 
-const sampleJson = `
-{
-	"id": 24,
-	"username": "hide_ur_pain",
-	"secret": "` + encryptedPlainText + `"
-}
-`
-
-type testType struct {
-	ID       int    `json:"id"`
-	Username string `json:"username"`
-	Secret   String `json:"secret"`
-}
-
-var testStruct = testType{
-	ID:       24,
-	Username: "hide_ur_pain",
-	Secret:   "plain text",
-}
-
-func TestString_UnmarshalJSONtoStruct(t *testing.T) {
-	z := newTestKeySentinel()
-	defer z.Reset()
-
-	var got testType
-	err := json.Unmarshal([]byte(sampleJson), &got)
+func TestEncryptedStringJSON(t *testing.T) {
+	c, _ := NewCipher(testKey)
+	secret, err := NewEncryptedString(c, "quote: \" and slash: \\")
 	if err != nil {
-		t.Errorf("Unmarshal() unexpected error: %s", err)
+		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(testStruct, got) {
-		t.Errorf("test structure doesn't match the unmashralled: want=%v, got=%v", testStruct, got)
+	data, err := json.Marshal(secret)
+	if err != nil {
+		t.Fatal(err)
 	}
-}
-
-func TestString_UnmarshalJSON(t *testing.T) {
-	z := newTestKeySentinel()
-	defer z.Reset()
-
-	type args struct {
-		b []byte
+	decoded, _ := NewEncryptedString(c, "")
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
 	}
-	tests := []struct {
-		name    string
-		args    args
-		wantES  String
-		wantErr bool
-	}{
-		{"unencrypted", args{[]byte("unencrypted")}, "unencrypted", false},
-		{"unencrypted quoted", args{[]byte("\"unencrypted\"")}, "unencrypted", false},
-		{"encrypted", args{[]byte(encryptedPlainText)}, "plain text", false},
-		{"encrypted quoted", args{[]byte(`"` + encryptedPlainText + `"`)}, "plain text", false},
-		{"invalid", args{[]byte(signature + "i must break you")}, "", true},
-		{"empty", args{[]byte{}}, "", false},
-		{"empty quoted", args{[]byte(`""`)}, "", false},
+	if decoded.Value() != secret.Value() {
+		t.Fatalf("got %q", decoded.Value())
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var es String
-			if err := es.UnmarshalJSON(tt.args.b); (err != nil) != tt.wantErr {
-				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if !reflect.DeepEqual(string(tt.wantES), string(es)) {
-				t.Errorf("UnmarshalJSON did not work as expected: want=%q, got=%q", string(tt.wantES), string(es))
-			}
-		})
+	decoded.Set("changed")
+	if decoded.String() != "changed" {
+		t.Fatalf("Set failed: %q", decoded.String())
 	}
 }
 
-func TestString_MarshalJSON(t *testing.T) {
-	z := newTestKeySentinel()
-	defer z.Reset()
-
-	tests := []struct {
-		name    string
-		es      String
-		want    string
-		wantErr bool
-	}{
-		{"plain text", String("plain text"), "plain text", false},
-		{"empty", String(""), ``, false},
+func TestEncryptedStringRejectsPlaintext(t *testing.T) {
+	c, _ := NewCipher(testKey)
+	strict, _ := NewEncryptedString(c, "")
+	if err := json.Unmarshal([]byte(`"plain"`), &strict); !errors.Is(err, ErrInvalidEnvelope) {
+		t.Fatalf("plaintext error = %v", err)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			encrypted, err := tt.es.MarshalJSON()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+	if err := json.Unmarshal([]byte(`null`), &strict); !errors.Is(err, ErrInvalidEnvelope) {
+		t.Fatalf("null error = %v", err)
+	}
+	if err := json.Unmarshal([]byte(`123`), &strict); err == nil {
+		t.Fatal("numeric JSON accepted")
+	}
 
-			encrypted = bytes.Trim(encrypted, `"`)
-			if len(encrypted) == 0 && len(tt.want) == 0 {
-				return // all good, empty string is an empty string.
-			}
-			got, err := Decrypt(string(encrypted))
-			if err != nil {
-				t.Errorf("unexpected decrypt error: %s", err)
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("MarshalJSON() got = %v, want %v", got, tt.want)
-			}
-		})
+	migration, _ := NewEncryptedString(c, "", WithPlaintextJSONMigration())
+	if err := json.Unmarshal([]byte(`"plain"`), &migration); err != nil {
+		t.Fatal(err)
+	}
+	if migration.Value() != "plain" {
+		t.Fatalf("got %q", migration.Value())
+	}
+	data, err := json.Marshal(migration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) == `"plain"` {
+		t.Fatal("migration value was not encrypted")
+	}
+}
+
+func TestEncryptedStringUnconfigured(t *testing.T) {
+	var value EncryptedString
+	if _, err := json.Marshal(value); !errors.Is(err, ErrUnconfigured) {
+		t.Fatalf("marshal error = %v", err)
+	}
+	if err := json.Unmarshal([]byte(`"x"`), &value); !errors.Is(err, ErrUnconfigured) {
+		t.Fatalf("unmarshal error = %v", err)
+	}
+	if _, err := NewEncryptedString(nil, ""); !errors.Is(err, ErrUnconfigured) {
+		t.Fatalf("constructor error = %v", err)
+	}
+	if _, err := NewEncryptedString(&Cipher{}, "", nil); err == nil {
+		t.Fatal("accepted nil JSON option")
 	}
 }


### PR DESCRIPTION
## Motivation

The v0 API relies on mutable package-wide configuration, a low-cost fixed-salt PBKDF2 setup, an unversioned ciphertext format, and unauthenticated AES-CFB streaming. These choices make concurrent use difficult to reason about, prevent safe cryptographic parameter migration, and leave streamed ciphertext open to undetected modification.

This change introduces a deliberately breaking v2 module so applications can migrate to secure defaults without preserving unsafe encryption APIs.

## Changes

- change the module path to `github.com/rusq/secure/v2`
- add immutable, concurrency-safe key and password cipher instances
- introduce canonical, versioned `SEC2.` AES-256-GCM envelopes with authenticated headers, associated data, and bounded parsing
- use fresh per-envelope salts and bounded Argon2id parameters for password encryption
- replace AES-CFB streams with authenticated 64 KiB records, per-stream subkeys, counters, and truncation detection
- replace global JSON aliases with instance-bound `EncryptedString` and `EncryptedInt` values
- reject plaintext JSON by default while providing an explicit migration option
- retain read-only `SEC.` migration helpers for default and customized v1 ciphertext
- remove global configuration, legacy encryption, and CFB APIs from v2
- document the v2 API, security model, stream requirements, and step-by-step upgrade process
- harden CI with race testing, coverage enforcement, fuzz smoke testing, vulnerability scanning, and pinned action revisions

## Developer impact

Consumers must update imports to the `/v2` path, construct and pass a cipher instance, and update JSON and stream integrations. Existing `SEC.` values can be decrypted and re-encrypted through the explicit legacy migration helpers. Historical CFB streams require a one-time migration using the original v0 key and IV; v2 does not retain runtime CFB support.

## Validation

- `go test ./... -race -count=2 -cover` — 91.2% statement coverage
- `go vet ./...`
- `go build ./...`
- `gofmt` and `git diff --check`
- `govulncheck ./...` — no reachable vulnerabilities
